### PR TITLE
Do not validate the tibble

### DIFF
--- a/R/type-cran.R
+++ b/R/type-cran.R
@@ -291,7 +291,7 @@ local({
       }
     })
 
-    res <- as_tibble(do.call(rbind, res), stringsAsFactors = FALSE)
+    res <- as_tibble(do.call(rbind, res), validate = FALSE)
     colnames(res) <- c("platform", "rversion", "contriburl")
     res$prefix <- paste0(
       "/",


### PR DESCRIPTION
This causes an error in tibble-devel

    Error: Columns 1, 3 must be named

Because we set the column names in the following line.
Passing `validate = FALSE` fixes the issue.

Fixes #36