### PR TITLE
Speed up solver

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pkgdepends
 Title: Package Dependency Resolution and Downloads
-Version: 0.0.0.9001
+Version: 0.0.0.9002
 Author: Gábor Csárdi
 Maintainer: Gábor Csárdi <csardi.gabor@gmail.com>
 Description: Find recursive dependenies of R packages from various sources.


### PR DESCRIPTION
What made the solver very slow is the essentially identical alternatives that it had to consider. E.g. the exact same version of a CRAN package, both in source and in binary form, and possibly even in an already installed form. We work around these now, and rule out cran/bioc/standard
- source packages if there is a binary with the same version number
- source and binary packages if there is an installed package (from cran/bioc!) with the same version number.

This results a great speedup already, except for the case when many non-standard packages are involved. (E.g. many packages being installed from GH or many _installed_ packages from GH in the library.)

The will work on solving these smaller issues later.