### PR TITLE
Handle package trees better

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pkgdepends
 Title: Package Dependency Resolution and Downloads
-Version: 0.0.0.9004
+Version: 0.0.0.9005
 Author: Gábor Csárdi
 Maintainer: Gábor Csárdi <csardi.gabor@gmail.com>
 Description: Find recursive dependenies of R packages from various sources.

--- a/R/download.R
+++ b/R/download.R
@@ -108,9 +108,10 @@ download_remote <- function(res, config, cache, which,
   remote_types <- c(default_remote_types(), remote_types)
   dl <- remote_types[[res$type]]$download %||% type_default_download
   target <- file.path(config$cache_dir, res$target)
+  target_tree <- file.path(config$cache_dir, paste0(res$target), "-tree")
   mkdirp(dirname(target))
-  asNamespace("pkgcache")$async(dl)(res, target, config, cache = cache,
-    which = which, on_progress = on_progress)$
+  asNamespace("pkgcache")$async(dl)(res, target, target_tree, config,
+    cache = cache, which = which, on_progress = on_progress)$
     then(function(s) {
       if (length(res$sources[[1]]) && !file.exists(target)) {
         stop("Failed to download ", res$type, " package ", res$package)
@@ -127,6 +128,7 @@ download_remote <- function(res, config, cache, which,
     catch(error = function(err) {
       dlres <- res
       dlres$fulltarget <- target
+      dlres$fulltarget_tree <- target_tree
       dlres$download_status <- "Failed"
       dlres$download_error <- list(err)
       dlres$file_size <- NA_integer_

--- a/R/remotes.R
+++ b/R/remotes.R
@@ -71,7 +71,7 @@
 #' * `sources` URLs to download the package from. CRAN URLs are not stable,
 #'   so each row typically contains multiple URLs here.
 #' * `target` Relative path for the package file in the repository.
-#' * `fulltarget` Fulle path for the package file in the cache.
+#' * `fulltarget` Full path for the package file in the cache.
 #'
 #' @section Configuration options:
 #' * `cache_dir` Path to the cache. By default a temporary directory is

--- a/R/solve.R
+++ b/R/solve.R
@@ -483,9 +483,14 @@ remotes_install_plan <- function(self, private, downloads) {
   sol$binary <- binary
   sol$direct <- direct
   sol$dependencies <- I(deps)
-  if (downloads) sol$file <- sol$fulltarget
   sol$installed <- installed
   sol$vignettes <- vignettes
+
+  if (downloads) {
+    ex <- file.exists(sol$fulltarget)
+    sol$packaged <- ex
+    sol$file <- ifelse(ex, sol$fulltarget, sol$fulltarget_tree)
+  }
 
   sol
 }

--- a/R/solve.R
+++ b/R/solve.R
@@ -487,9 +487,9 @@ remotes_install_plan <- function(self, private, downloads) {
   sol$vignettes <- vignettes
 
   if (downloads) {
-    ex <- file.exists(sol$fulltarget)
-    sol$packaged <- ex
-    sol$file <- ifelse(ex, sol$fulltarget, sol$fulltarget_tree)
+    tree <- ! file.exists(sol$fulltarget) & file.exists(sol$fulltarget_tree)
+    sol$packaged <- !tree
+    sol$file <- ifelse(tree, sol$fulltarget_tree, sol$fulltarget)
   }
 
   sol

--- a/R/type-bioc.R
+++ b/R/type-bioc.R
@@ -23,8 +23,8 @@ resolve_remote_bioc <- function(remote, direct, config, cache,
   resolve_from_metadata(remote, direct, config, cache, dependencies)
 }
 
-download_remote_bioc <- function(resolution, target, config, cache,
-                                 which, on_progress) {
+download_remote_bioc <- function(resolution, target, target_tree, config,
+                                 cache, which, on_progress) {
 
   download_ping_if_not_source(resolution, target, config, cache,
                               on_progress)

--- a/R/type-cran.R
+++ b/R/type-cran.R
@@ -37,8 +37,8 @@ resolve_remote_cran <- function(remote, direct, config, cache,
   }
 }
 
-download_remote_cran <- function(resolution, target, config, cache,
-                                 which, on_progress) {
+download_remote_cran <- function(resolution, target, target_tree, config,
+                                 cache, which, on_progress) {
 
   download_ping_if_no_sha(resolution, target, config, cache,
                           on_progress)

--- a/R/type-deps.R
+++ b/R/type-deps.R
@@ -20,8 +20,8 @@ resolve_remote_deps <- function(remote, direct, config, cache,
   ret
 }
 
-download_remote_deps <- function(resolution, target, config, cache,
-                                  which, on_progress) {
+download_remote_deps <- function(resolution, target, target_tree, config,
+                                 cache, which, on_progress) {
   ## Nothing to do here
   "Had"
 }

--- a/R/type-github.R
+++ b/R/type-github.R
@@ -67,7 +67,7 @@ download_remote_github <- function(resolution, target, target_tree,
   ## vignettes is fine.
 
   hit <- cache$package$copy_to(
-    target, package = package, sha = sha, built = TRUE,
+    target, package = package, sha256 = sha, built = TRUE,
     .list = c(if (need_vignettes) c(vignettes = TRUE)))
   if (nrow(hit)) {
     "!DEBUG found GH `resolution$ref`@`sha` in the cache"
@@ -79,7 +79,7 @@ download_remote_github <- function(resolution, target, target_tree,
   rel_target <- resolution$target
   subdir <- resolution$remote[[1]]$subdir
   hit <- cache$package$copy_to(
-    target_tree, package = package, sha = sha, built = FALSE)
+    target_tree, package = package, sha256 = sha, built = FALSE)
   if (nrow(hit)) {
     "!DEBUG found GH zip for `resolution$ref`@`sha` in the cache"
     return("Had")
@@ -89,7 +89,7 @@ download_remote_github <- function(resolution, target, target_tree,
 
   "!DEBUG Need to download GH package `resolution$ref`@`sha`"
   urls <- resolution$sources[[1]]
-  rel_zip <- sub("\\.tar\\.gz$", ".tree-zip", rel_target)
+  rel_zip <- paste0(rel_target, "-tree")
   type_github_download_repo(urls, target_tree, rel_zip, sha, package, cache,
                             on_progress)$
     then(function() {

--- a/R/type-installed.R
+++ b/R/type-installed.R
@@ -24,8 +24,8 @@ resolve_remote_installed <- function(remote, direct, config,
   resolve_installed(cache, remote, direct, deps)
 }
 
-download_remote_installed <- function(resolution, target, config, cache,
-                                      which, on_progress) {
+download_remote_installed <- function(resolution, target, target_cache,
+                                      config, cache, which, on_progress) {
   "Had"
 }
 

--- a/R/type-installed.R
+++ b/R/type-installed.R
@@ -24,7 +24,7 @@ resolve_remote_installed <- function(remote, direct, config,
   resolve_installed(cache, remote, direct, deps)
 }
 
-download_remote_installed <- function(resolution, target, target_cache,
+download_remote_installed <- function(resolution, target, target_tree,
                                       config, cache, which, on_progress) {
   "Had"
 }

--- a/R/type-local.R
+++ b/R/type-local.R
@@ -22,8 +22,8 @@ resolve_remote_local <- function(remote, direct, config, cache,
                            config, cache, dependencies[[2 - direct]])
 }
 
-download_remote_local <- function(resolution, target, config, cache,
-                                  which, on_progress) {
+download_remote_local <- function(resolution, target, target_tree, config,
+                                  cache, which, on_progress) {
 
   source_file <- sub("^file://",  "",  resolution$sources[[1]])
   if (! file.copy(source_file, target, overwrite =  TRUE)) {

--- a/R/type-local.R
+++ b/R/type-local.R
@@ -26,10 +26,22 @@ download_remote_local <- function(resolution, target, target_tree, config,
                                   cache, which, on_progress) {
 
   source_file <- sub("^file://",  "",  resolution$sources[[1]])
-  if (! file.copy(source_file, target, overwrite =  TRUE)) {
-    stop("No local file found")
+  isdir <- file.info(source_file)$isdir
+  if (is.na(isdir)) stop("Local file not found")
+
+  if (isdir) {
+    unlink(target_tree, recursive = TRUE)
+    mkdirp(target_tree)
+    if (! file.copy(source_file, target_tree, recursive = TRUE)) {
+      stop("No local file found")
+    }
+  } else {
+    if (! file.copy(source_file, target, overwrite = TRUE)) {
+      stop("No local file found")
+    }
   }
-  "Had"
+
+  "Got"
 }
 
 satisfy_remote_local <- function(resolution, candidate, config, ...) {

--- a/R/type-standard.R
+++ b/R/type-standard.R
@@ -21,8 +21,8 @@ resolve_remote_standard <- function(remote, direct, config,
   resolve_from_metadata(remote, direct, config, cache, dependencies)
 }
 
-download_remote_standard <- function(resolution, target, config, cache,
-                                     which, on_progress) {
+download_remote_standard <- function(resolution, target, target_tree,
+                                     config, cache, which, on_progress) {
 
   download_ping_if_no_sha(resolution, target, config, cache,
                           on_progress)

--- a/tests/testthat/test-type-bioc.R
+++ b/tests/testthat/test-type-bioc.R
@@ -91,15 +91,18 @@ test_that("download_remote", {
                         dependencies = FALSE))
 
   target <- file.path(conf$cache_dir, res$target[1])
+  tree <- paste0(target, "-tree")
   dl <- asNamespace("pkgcache")$synchronise(
-    download_remote_bioc(res[1,], target, conf, cache, on_progress = NULL))
+    download_remote_bioc(res[1,], target, tree, conf, cache,
+                         on_progress = NULL))
 
   expect_equal(dl, "Got")
   expect_true(file.exists(target))
 
   unlink(target)
   dl2 <- asNamespace("pkgcache")$synchronise(
-    download_remote_bioc(res[1,], target, conf, cache, on_progress = NULL))
+    download_remote_bioc(res[1,], target, tree, conf, cache,
+                         on_progress = NULL))
   expect_true(dl2 %in% c("Had", "Current"))
   expect_true(file.exists(target))
 })

--- a/tests/testthat/test-type-cran.R
+++ b/tests/testthat/test-type-cran.R
@@ -223,8 +223,9 @@ test_that("download_remote", {
   res <- asNamespace("pkgcache")$synchronise(resolve())
 
   target <- file.path(conf$cache_dir, res$target[1])
+  tree <- paste0(target, "-tree")
   download <- function(res) {
-    download_remote_cran(res, target, conf, cache, on_progress = NULL)
+    download_remote_cran(res, target, tree, conf, cache, on_progress = NULL)
   }
   dl1 <- asNamespace("pkgcache")$synchronise(download(res[1,]))
   expect_equal(dl1, "Got")

--- a/tests/testthat/test-type-github.R
+++ b/tests/testthat/test-type-github.R
@@ -99,12 +99,19 @@ test_that("download_remote", {
   skip_if_offline()
   skip_on_cran()
 
+  old_cache <- Sys.getenv("R_PKG_CACHE_DIR")
+  on.exit(Sys.setenv(R_PKG_CACHE_DIR = old_cache))
+  Sys.setenv(R_PKG_CACHE_DIR = cache <- tempfile())
+  on.exit(unlink(cache, recursive = TRUE), add = TRUE)
+
   dir.create(tmp <- tempfile())
   on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
 
   ref <- "github::r-lib/crayon@b5221ab0246050dc687dc8b9964d5c44c947b265"
   r <- remotes()$new(
     ref, config = list(dependencies = FALSE, cache_dir = tmp))
+
+  ## We get the tree zip first
   withr::with_options(
     c(pkg.show_progress = FALSE), {
       expect_error(r$resolve(), NA)

--- a/tests/testthat/test-type-local.R
+++ b/tests/testthat/test-type-local.R
@@ -107,7 +107,7 @@ test_that("download_remote", {
     download_remote_local(res, target, conf, cache, on_progress = NULL)
   }
   dl1 <- asNamespace("pkgcache")$synchronise(download(res[1,]))
-  expect_equal(dl1, "Had")
+  expect_equal(dl1, "Got")
   expect_true(file.exists(target))
 
   ## Relative path?
@@ -124,7 +124,7 @@ test_that("download_remote", {
   mkdirp(dirname(target))
   dl1 <- download_remote_local(res, target, conf, cache, on_progress = NULL)
 
-  expect_equal(dl1, "Had")
+  expect_equal(dl1, "Got")
   expect_true(file.exists(target))
 })
 

--- a/tests/testthat/test-type-standard.R
+++ b/tests/testthat/test-type-standard.R
@@ -72,15 +72,18 @@ test_that("download_remote", {
                         dependencies = FALSE))
 
   target <- file.path(conf$cache_dir, res$target[1])
+  tree <- paste0(target, "-tree")
   dl <- asNamespace("pkgcache")$synchronise(
-    download_remote_bioc(res[1,], target, conf, cache, on_progress = NULL))
+    download_remote_bioc(res[1,], target, tree, conf, cache,
+                         on_progress = NULL))
 
   expect_equal(dl, "Got")
   expect_true(file.exists(target))
 
   unlink(target)
   dl2 <- asNamespace("pkgcache")$synchronise(
-    download_remote_bioc(res[1,], target, conf, cache, on_progress = NULL))
+    download_remote_bioc(res[1,], target, tree, conf, cache,
+                         on_progress = NULL))
   expect_true(dl2 %in% c("Had", "Current"))
   expect_true(file.exists(target))
 })


### PR DESCRIPTION
Now creating a source R package is a separate step. This means:

* Download methods for the various remotes can produce either of these

  1. a proper source package
  2. a compressed (zip or tar.gz) file with a package tree
  3. an uncompressed package tree.

  A GH download will produce 2., a `local::` file will also produce 2., a `local::` directory will produce 3. 2. and 3. are produced at an alternate location (`target_tree`). We want to defer (un)compressing to installation time, that's why we support both 2. and 3.

* In the install plan, `file` will point to the tree, in case of 2. and 3.

* In the install plan, the new `packaged` column will denote whether `file` is a proper source package. 

* GitHub packages now do not do `R CMD build` upon downloading the package tree. This is good, because building might take a long time, or even fail, if the package needs to be installed because of dynamic manual pages, and some of its dependencies are missing.

* Local packages now copy the package file or directory into the download area, at download time.

Closes #131.