### PR TITLE
Do not build vignettes for package trees by default

### DIFF
--- a/R/pkg-plan.R
+++ b/R/pkg-plan.R
@@ -163,7 +163,12 @@ pkgplan_init <- function(self, private, refs, config, library,
 #'   Defaults to the hard dependencies, see [pkg_dep_types_hard()].
 #' * `r-versions`: Character vector, R versions to download or install
 #'   packages for. It defaults to the current R version.
-#'
+#' * `build-vignettes`: Whether to build vignettes for package trees.
+#'   This is only used if the package is obtained from a package tree,
+#'   and not from a source (or binary) package archive. By default vignettes
+#'   are not built in this case. If you set this to `TRUE`, then you need
+#'   to make sure that the vignette builder packages are available, as
+#'   these are not installed by default currently.
 #' @name pkg_config
 NULL
 
@@ -176,7 +181,8 @@ pkgplan_default_config <- function() {
     "platforms"          = default_platforms(),
     "cran-mirror"        = default_cran_mirror(),
     "dependencies"       = pkg_dep_types_hard(),
-    "r-versions"         = current_r_version()
+    "r-versions"         = current_r_version(),
+    "build-vignettes"    = FALSE
   ), class = "pkg_config")
 }
 
@@ -198,8 +204,9 @@ format.pkg_config <- function(x, ...) {
     paste0("  - platforms: ", paste(x$platforms, collapse = ", ")),
     paste0("  - cran-mirror: ", x$`cran-mirror`),
     paste0("  - dependencies: ", format_dependencies(x$dependencies)),
-    paste0("  - r-versions: ", paste(x$`r-versions`, collapse = ", "))
-    )
+    paste0("  - r-versions: ", paste(x$`r-versions`, collapse = ", ")),
+    paste0("  - build-vignettes: ", x$`build-vignettes`)
+  )
 }
 
 #' @export
@@ -221,7 +228,8 @@ is_valid_config <- function(x) {
       platforms          = assert_that(is_platform_list(x[[n]])),
       "cran-mirror"      = assert_that(is_string(x[[n]])),
       dependencies       = assert_that(is_dependencies(x[[n]])),
-      "r-versions"       = assert_that(is_r_version_list(x[[n]]))
+      "r-versions"       = assert_that(is_r_version_list(x[[n]])),
+      "build-vignettes"  = assert_that(is_flag(x[[n]]))
     )
   }
   TRUE

--- a/R/solve.R
+++ b/R/solve.R
@@ -552,7 +552,8 @@ pkgplan_install_plan <- function(self, private, downloads) {
     (sol$type == "installed" & sol$package %in% direct_packages)
 
   binary = sol$platform != "source"
-  vignettes <- ! binary & ! sol$type %in% c("cran", "bioc", "standard")
+  vignettes <- ! binary & ! sol$type %in% c("cran", "bioc", "standard") &
+    private$config$`build-vignettes`
 
   sol$library <- private$config$library
   sol$binary <- binary

--- a/R/utils.R
+++ b/R/utils.R
@@ -442,3 +442,9 @@ has_asciicast_support <- function() {
 try_silently <- function(expr) {
   try(expr, silent = TRUE)
 }
+
+rimraf <- function(...) {
+  x <- file.path(...)
+  if ("~" %in% x) stop("Cowardly refusing to delete `~`")
+  unlink(x, recursive = TRUE, force = TRUE)
+}

--- a/man/pkg_config.Rd
+++ b/man/pkg_config.Rd
@@ -38,5 +38,11 @@ to the current platform, \emph{and} \code{source}.
 Defaults to the hard dependencies, see \code{\link[=pkg_dep_types_hard]{pkg_dep_types_hard()}}.
 \item \code{r-versions}: Character vector, R versions to download or install
 packages for. It defaults to the current R version.
+\item \code{build-vignettes}: Whether to build vignettes for package trees.
+This is only used if the package is obtained from a package tree,
+and not from a source (or binary) package archive. By default vignettes
+are not built in this case. If you set this to \code{TRUE}, then you need
+to make sure that the vignette builder packages are available, as
+these are not installed by default currently.
 }
 }

--- a/tests/testthat/fixtures/packages/vignettes/DESCRIPTION
+++ b/tests/testthat/fixtures/packages/vignettes/DESCRIPTION
@@ -1,0 +1,13 @@
+Package: pkgdependstest
+Title: Title
+Version: 1.0.0
+Author: Gábor Csárdi
+Maintainer: Gábor Csárdi <csardi.gabor@gmail.com>
+Description: Test package.
+License: MIT + file LICENSE
+LazyData: true
+VignetteBuilder: knitr
+Suggests:
+  knitr,
+  rmarkdown
+Encoding: UTF-8

--- a/tests/testthat/fixtures/packages/vignettes/R/foo.R
+++ b/tests/testthat/fixtures/packages/vignettes/R/foo.R
@@ -1,0 +1,1 @@
+fun <- function() NULL

--- a/tests/testthat/fixtures/packages/vignettes/vignettes/test.Rmd
+++ b/tests/testthat/fixtures/packages/vignettes/vignettes/test.Rmd
@@ -1,0 +1,12 @@
+---
+title: "pkgdepends HOWTO"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{pkgdepends test}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r}
+print("Hello there!")
+```

--- a/tests/testthat/test-build.R
+++ b/tests/testthat/test-build.R
@@ -7,3 +7,30 @@ test_that("build_package", {
   build_package(tmp <- tempfile())
   expect_equal(args$path, tmp)
 })
+
+test_that("vignettes can be turned on and off", {
+  skip_if_offline()
+  dir.create(tmplib <- tempfile())
+  on.exit(rimraf(tmplib), add = TRUE)
+  pkgdir <- test_path("fixtures", "packages", "vignettes")
+  inst <- new_pkg_installation_proposal(
+    paste0("local::", pkgdir),
+    config = list(`build-vignettes` = FALSE, library = tmplib)
+  )
+  inst$solve()
+  inst$download()
+  inst$install()
+
+  expect_false("doc" %in% dir(file.path(tmplib, "pkgdependstest")))
+  rimraf(tmplib, "pkgdependstest")
+
+  inst2 <- new_pkg_installation_proposal(
+    paste0("local::", pkgdir),
+    config = list(`build-vignettes` = TRUE, library = tmplib)
+  )
+  inst2$solve()
+  inst2$download()
+  inst2$install()
+
+  expect_true("doc" %in% dir(file.path(tmplib, "pkgdependstest")))
+})


### PR DESCRIPTION
Can be turned on in the config with `build-vignettes = TRUE`,
but the vignette builder packages are not automatically installed
currently. (But see https://github.com/r-lib/pkgdepends/issues/155.)

Closes #150.