### PR TITLE
fix bad ref check

### DIFF
--- a/R/parse-remotes.R
+++ b/R/parse-remotes.R
@@ -184,7 +184,7 @@ parse_pkg_refs <- function(refs, remote_types = NULL, ...) {
   unique_types <- unique(types)
   res <- vector("list", length(refs))
 
-  if (any(bad <- setdiff(unique_types, names(remote_types)))) {
+  if (length(bad <- setdiff(unique_types, names(remote_types))) > 0) {
     stop("Unknown remote type(s): ", format_items(bad))
   }
 


### PR DESCRIPTION
Fixes #172 so the error message is as intended:

```
r$> inst <- new_pkg_installation_proposal("xxx::foo",
        config=list(library="~/insttmp"))
Error in parse_pkg_refs(refs) : Unknown remote type(s): `xxx`
```