### PR TITLE
Support disabling the progress bar

### DIFF
--- a/R/install-progress-bar.R
+++ b/R/install-progress-bar.R
@@ -24,6 +24,9 @@ create_progress_bar <- function(state) {
 #' @importFrom cli cli_status_update
 
 update_progress_bar <- function(state, tick = 0) {
+  if (!isTRUE(getOption("pkg.show_progress", FALSE))) {
+    return()
+  }
 
   plan <- state$plan
   total <- nrow(plan)


### PR DESCRIPTION
This adds an argument to disable the progress bar, which doesn't work very well in CI logs.

I will need an accompanying PR in pak to disable the bar, maybe when the `CI` environment variable is set.