### PR TITLE
Do not use R CMD INSTALL locking

### DIFF
--- a/R/install-plan.R
+++ b/R/install-plan.R
@@ -327,8 +327,9 @@ make_build_process <- function(path, tmp_dir, lib, vignettes,
     pkgbuild_process$new(
       path, tmp_dir, binary = binary, vignettes = vignettes,
       needs_compilation = needscompilation, compile_attributes = FALSE,
-      args = if (binary) glue("--library={lib}"))
+      args = c("--no-lock", if (binary) glue("--library={lib}"))
     )
+  )
 }
 
 start_task_package <- function(state, task) {


### PR DESCRIPTION
pkgdepends does its own locking, so we don't want to use R's

Fixes #184