### PR TITLE
Set done prior to recursive call

### DIFF
--- a/R/install-plan.R
+++ b/R/install-plan.R
@@ -129,9 +129,9 @@ add_recursive_dependencies <- function(plan) {
   do <- function(i) {
     if (done[[i]]) return()
     miss <- idx[names(!done[xdps[[i]]])]
+    done[[i]] <<- TRUE
     for (m in miss) do(m)
     xdps[[i]] <<- unique(c(xdps[[i]], unlist(xdps[xdps[[i]]])))
-    done[[i]] <<- TRUE
   }
 
   for (i in srcidx) do(i)


### PR DESCRIPTION
To protect against adding the same dependency multiple times

This fixes #195 and all the tests pass with it, so I don't think it should hurt the behavior. But another set of eyes would be helpful.