### PR TITLE
Avoid a partial match

### DIFF
--- a/R/solve.R
+++ b/R/solve.R
@@ -110,7 +110,7 @@ pkgplan_solve <- function(self, private, policy) {
 
   metadata <- list(solution_start = Sys.time())
   pkgs <- self$get_resolution()
-  rversion <- private$config$`r-version`
+  rversion <- private$config$`r-versions`
 
   prb <- private$create_lp_problem(pkgs, policy, rversion)
   sol <- private$solve_lp_problem(prb)


### PR DESCRIPTION
Fixes this

```
>   pd <- new_pkg_deps("local::.")
> pd$solve()
Warning message:                                            
partial match of 'r-version' to 'r-versions' 
```