### PR TITLE
Improve failure messages

### DIFF
--- a/R/resolution.R
+++ b/R/resolution.R
@@ -555,7 +555,7 @@ get_standard_metadata <- function(tab) {
 make_failed_resolution <- function(refs, type, direct) {
   rstr <- paste(refs, collapse = ", ")
   err <- structure(
-    list(message = paste0("Cannot find standard ref(s): ", rstr)),
+    list(message = paste0("Can't find package called ", rstr, ".")),
     class = c("error", "condition"))
   tibble(
     ref = refs,

--- a/R/solve.R
+++ b/R/solve.R
@@ -110,7 +110,7 @@ pkgplan_solve <- function(self, private, policy) {
 
   metadata <- list(solution_start = Sys.time())
   pkgs <- self$get_resolution()
-  rversion <- private$config$`r-version`
+  rversion <- private$config$`r-versions`
 
   prb <- private$create_lp_problem(pkgs, policy, rversion)
   sol <- private$solve_lp_problem(prb)

--- a/R/solve.R
+++ b/R/solve.R
@@ -881,7 +881,7 @@ describe_solution_error <- function(pkgs, solution) {
     down <- pkgs$ref[sv]
     up <- pkgs$ref[cnd[[w]]$note]
     state[sv] <- "satisfy-direct"
-    note[[sv]] <- c(note[[sv]], glue("Conflicts {up}"))
+    note[[sv]] <- c(note[[sv]], glue("Conflicts with {up}"))
   }
 
   ## Find "conflict". These are candidates that are not installed,
@@ -897,7 +897,7 @@ describe_solution_error <- function(pkgs, solution) {
       for (v in vv) {
         note[[v]] <- c(
           note[[v]],
-          glue("{pkgs$ref[v]} conflict with {inst}, to be installed"))
+          glue("{pkgs$ref[v]} conflicts with {inst}, to be installed"))
       }
     }
   }
@@ -913,7 +913,7 @@ describe_solution_error <- function(pkgs, solution) {
     pkg <- cnd[type_dep][[x]]$note$ref
     state[dep_up[x]] <- "dep-failed"
     note[[ dep_up[x] ]] <-
-      c(note[[ dep_up[x] ]], glue("Cannot install dependency {pkg}"))
+      c(note[[ dep_up[x] ]], glue("Can't install dependency {pkg}"))
     downstream[[ dep_up[x] ]] <- c(downstream[[ dep_up[x] ]], pkg)
   }
 
@@ -927,7 +927,7 @@ describe_solution_error <- function(pkgs, solution) {
       pkg <- cnd[type_dep][[x]]$note$ref
       state[ dep_up[x] ] <- "dep-failed"
       note[[ dep_up[x] ]] <- c(
-        note[[ dep_up[x] ]], glue("Cannot install dependency {pkg}"))
+        note[[ dep_up[x] ]], glue("Can't install dependency {pkg}"))
       downstream[[ dep_up[x] ]] <- c(downstream[[ dep_up[x] ]], pkg)
     }
     new <- dep_up[which_new]
@@ -959,12 +959,15 @@ format.pkg_solution_failures <- function(x, ...) {
     if (done[i]) return()
     done[i] <<- TRUE
     msgs <- unique(fails$failure_message[[i]])
-    res <<- c(
-      res, paste0(
-             glue("  x Cannot install `{fails$ref[i]}`."),
-             if (length(msgs)) paste0("\n    - ", msgs)
-           )
-    )
+
+    fail <- paste0("* ", crayon::bold(fails$ref[i]))
+    if (length(msgs) == 1) {
+      fail <- paste0(fail, ": ", msgs)
+    } else {
+      fail <- paste0(fail, ".\n", paste0("  * ", msgs, "\n"))
+    }
+
+    res <<- c(res, fail)
     down <- which(fails$ref %in% fails$failure_down[[i]])
     lapply(down, do)
   }

--- a/R/solve.R
+++ b/R/solve.R
@@ -960,11 +960,11 @@ format.pkg_solution_failures <- function(x, ...) {
     done[i] <<- TRUE
     msgs <- unique(fails$failure_message[[i]])
 
-    fail <- paste0("* ", crayon::bold(fails$ref[i]))
+    fail <- paste0("* ", crayon::bold(fails$ref[i]), ":")
     if (length(msgs) == 1) {
-      fail <- paste0(fail, ": ", msgs)
+      fail <- paste0(fail, " ", msgs)
     } else {
-      fail <- paste0(fail, ".\n", paste0("  * ", msgs, "\n"))
+      fail <- paste0(fail, "\n", paste0("  * ", msgs, collapse = "\n"))
     }
 
     res <<- c(res, fail)

--- a/R/type-github.R
+++ b/R/type-github.R
@@ -436,34 +436,26 @@ new_github_query_error <- function(rem, response, obj, call. = NULL) {
 # No such user/org
 
 new_github_nouser_error <- function(rem, obj, call. = NULL) {
-  ghmsgs <- sub("\\.?$", ".", vcapply(obj$errors, "[[", "message"))
-  ghmsg <- grep("Could not resolve to a User", ghmsgs, value = TRUE)[1]
-  msg <- glue(
-    "Cannot resolve GitHub repo `{rem$username}/{rem$repo}`. ",
-    "{ghmsg}"
+  new_github_error(
+    "Can't find GitHub user {rem$username}.",
+    call. = call.
   )
-  new_github_error(msg, call. = call.)
 }
 
 # No such repo
 
 new_github_norepo_error <- function(rem, obj, call. = NULL) {
-  ghmsgs <- sub("\\.?$", ".", vcapply(obj$errors, "[[", "message"))
-  ghmsg <- grep("Could not resolve to a Repository", ghmsgs, value = TRUE)[1]
-  msg <- glue(
-    "Cannot resolve GitHub repo `{rem$username}/{rem$repo}`. ",
-    "{ghmsg}"
+  new_github_error(
+    glue("Can't find GitHub repo {rem$username}/{rem$repo}."),
+    call. = call.
   )
-  new_github_error(msg, call. = call.)
 }
-
 # Not an R package?
 
 new_github_no_package_error <- function(rem, call. = NULL) {
-  subdir <- rem$subdir %&z&% paste0(", in directory `", rem$subdir, "`")
+  subdir <- rem$subdir %&z&% paste0(" in directory '", rem$subdir, "'")
   msg <- glue(
-    "Cannot find R package in GitHub repo ",
-    "`{rem$username}/{rem$repo}`{subdir}"
+    "Can't find R package in GitHub repo {rem$username}/{rem$repo}{subdir}"
   )
   new_github_error(msg, call. = call.)
 }
@@ -482,29 +474,24 @@ new_github_badpat_error <- function(call. = NULL) {
 new_github_baddesc_error <- function(rem, call. = NULL) {
   subdir <- rem$subdir %&z&% paste0(", in directory `", rem$subdir, "`")
   msg <- glue(
-    "Cannot parse DESCRIPTION file in GitHub repo ",
-    "`{rem$username}/{rem$repo}`{subdir}"
+    "Can't parse DESCRIPTION file in GitHub repo {rem$username}/{rem$repo}`{subdir}"
   )
-  new_github_error(msg)
+  new_github_error(msg, call. = call.)
 }
 
 # No such PR
 
 new_github_nopr_error <- function(rem, obj, call. = NULL) {
-  msg <- glue(
-    "Cannot find pull request #{rem$pull} at repo ",
-    "`{rem$username}/{rem$repo}`"
-  )
-  new_github_error(msg)
+  msg <- glue("Can't find PR #{rem$pull} in GitHub repo {rem$username}/{rem$repo}")
+  new_github_error(msg, call. = call.)
 }
 
 # No such branch/tag/ref
 
 new_github_noref_error <- function(rem, call. = NULL) {
   ref <- rem$commitish %|z|% "HEAD"
-  msg <- glue("Cannot find branch/tag/commit `{ref}` in ",
-              "GitHub repo `{rem$username}/{rem$repo}`.")
-  new_github_error(msg)
+  msg <- glue("Can't find reference @{ref} in GitHub repo {rem$username}/{rem$repo}.")
+  new_github_error(msg, call. = call.)
 }
 
 # Rate limited

--- a/tests/testthat/test-github-tools.R
+++ b/tests/testthat/test-github-tools.R
@@ -33,14 +33,14 @@ test_that("type_github_get_data, no such user", {
   rem <- parse_pkg_ref("r-lib-xxx-xxx/pak")
   expect_error(
     synchronise(type_github_get_data(rem)),
-    "Could not resolve to a Repository .*r-lib-xxx-xxx.*",
+    "Can't find GitHub repo .*r-lib-xxx-xxx.*",
     class = "github_error"
   )
 
   rem <- parse_pkg_ref("r-lib-xxx-xxx/pak#90")
   expect_error(
     synchronise(type_github_get_data(rem)),
-    "Could not resolve to a Repository .*r-lib-xxx-xxx.*",
+    "Can't find GitHub repo .*r-lib-xxx-xxx.*",
     class = "github_error"
   )
 })
@@ -51,14 +51,14 @@ test_that("type_github_get_data, no such repo", {
   rem <- parse_pkg_ref("r-lib/pak-xxx-xxx")
   expect_error(
     synchronise(type_github_get_data(rem)),
-    "Repository with the name .*pak-xxx-xxx.*",
+    "GitHub repo .*pak-xxx-xxx.*",
     class = "github_error"
   )
 
   rem <- parse_pkg_ref("r-lib/pak-xxx-xxx#90")
   expect_error(
     synchronise(type_github_get_data(rem)),
-    "Repository with the name .*pak-xxx-xxx.*",
+    "GitHub repo .*pak-xxx-xxx.*",
     class = "github_error"
   )
 })
@@ -112,7 +112,7 @@ test_that("github_query, access denied", {
   rem <- parse_pkg_ref("gaborcsardi/secret-test")
   expect_error(
     synchronise(type_github_get_data(rem)),
-    "Repository with the name .*secret-test*",
+    "GitHub repo .*secret-test*",
     class = "github_error"
   )
 })
@@ -120,17 +120,24 @@ test_that("github_query, access denied", {
 test_that("cannot find R package on GitHub, no DESCRIPTION", {
   skip_if_offline()
 
+  rem <- parse_pkg_ref("tidyverse/tidyverse.org")
+  expect_error(
+    synchronise(type_github_get_data(rem)),
+    "Can't find R package in GitHub repo tidyverse/tidyverse.org",
+    class = "github_error"
+  )
+
   rem <- parse_pkg_ref("r-lib/crayon/R")
   expect_error(
     synchronise(type_github_get_data(rem)),
-    "Cannot find R package in GitHub repo `r-lib/crayon`, in directory `R`",
+    "Can't find R package in GitHub repo r-lib/crayon in directory 'R'",
     class = "github_error"
   )
 
   rem <- parse_pkg_ref("r-lib/crayon/R#79")
   expect_error(
     synchronise(type_github_get_data(rem)),
-    "Cannot find R package in GitHub repo `r-lib/crayon`, in directory `R`",
+    "Can't find R package in GitHub repo r-lib/crayon in directory 'R'",
     class = "github_error"
   )
 })
@@ -141,14 +148,14 @@ test_that("cannot parse DESCRIPTION on GH", {
   ref <- "r-lib/pkgdepends/tests/testthat/fixtures/bad-desc@f5a84c34f5"
   expect_error(
     synchronise(type_github_get_data(parse_pkg_ref(ref))),
-    "Cannot parse DESCRIPTION file in GitHub repo",
+    "Can't parse DESCRIPTION file in GitHub repo",
     class = "github_error"
   )
 
   ref <- "r-lib/pkgdepends/tests/testthat/fixtures/bad-desc#144"
   expect_error(
     synchronise(type_github_get_data(parse_pkg_ref(ref))),
-    "Cannot parse DESCRIPTION file in GitHub repo",
+    "Can't parse DESCRIPTION file in GitHub repo",
     class = "github_error"
   )
 })
@@ -170,7 +177,7 @@ test_that("no such PR error", {
   rem <- parse_pkg_ref("r-lib/pak#89")
   expect_error(
     synchronise(type_github_get_data(rem)),
-    "Cannot find pull request #89 at repo",
+    "Can't find PR #89 in",
     class = "github_error"
   )
 })
@@ -179,9 +186,7 @@ test_that("no such ref error", {
   rem <- parse_pkg_ref("r-lib/pak@bad-ref-no-no-no")
   expect_error(
     synchronise(type_github_get_data(rem)),
-    paste0(
-      "Cannot find branch/tag/commit `bad-ref-no-no-no` ",
-      "in GitHub repo `r-lib/pak`"),
+    "Can't find reference @bad-ref-no-no-no in GitHub repo r-lib/pak",
     fixed = TRUE,
     class = "github_error"
   )

--- a/tests/testthat/test-solve-describe.R
+++ b/tests/testthat/test-solve-describe.R
@@ -31,7 +31,7 @@ test_that("failed resolution", {
   expect_equal(dsc$direct, TRUE)
   expect_equal(dsc$status, "FAILED")
   expect_equal(dsc$failure_type, "failed-res")
-  expect_match(dsc$failure_message[[1]], "Cannot find standard ref")
+  expect_match(dsc$failure_message[[1]], "Can't find package")
 })
 
 test_that("failed resolution of a dependency", {

--- a/tests/testthat/test-solve-describe.R
+++ b/tests/testthat/test-solve-describe.R
@@ -53,8 +53,8 @@ test_that("failed resolution of a dependency", {
   expect_equal(dsc$failure_type, c("dep-failed", "dep-failed", "failed-res"))
   expect_equal(
     dsc$failure_message,
-    list("Cannot install dependency bb",
-         "Cannot install dependency cc",
+    list("Can't install dependency bb",
+         "Can't install dependency cc",
          "EEE"))
 })
 
@@ -72,7 +72,7 @@ test_that("conflicting direct refs", {
   expect_equal(dsc$failure_type, c("satisfy-direct", "satisfy-direct"))
   expect_equal(
     dsc$failure_message,
-    list("Conflicts aa/aa", "Conflicts cran::aa"))
+    list("Conflicts with aa/aa", "Conflicts with cran::aa"))
 })
 
 test_that("dependency conflicts direct ref", {
@@ -92,9 +92,9 @@ test_that("dependency conflicts direct ref", {
                                    "dep-failed"))
   expect_equal(
     dsc$failure_message,
-    list("Conflicts cran::aa",
-         "Cannot install dependency cc",
-         "Cannot install dependency aa/aa"))
+    list("Conflicts with cran::aa",
+         "Can't install dependency cc",
+         "Can't install dependency aa/aa"))
 })
 
 test_that("conflicting dependencies", {
@@ -115,8 +115,8 @@ test_that("conflicting dependencies", {
   expect_equal(dsc$failure_type, c("dep-failed", "conflict"))
   expect_equal(
     dsc$failure_message,
-    list("Cannot install dependency cran::cc",
-         "cran::cc conflict with cc/cc, to be installed"))
+    list("Can't install dependency cran::cc",
+         "cran::cc conflicts with cc/cc, to be installed"))
 })
 
 test_that("conflicting dependencies downstream", {
@@ -138,7 +138,7 @@ test_that("conflicting dependencies downstream", {
   expect_equal(dsc$failure_type, c("dep-failed", "dep-failed", "conflict"))
   expect_equal(
     dsc$failure_message,
-    list("Cannot install dependency bb",
-         "Cannot install dependency cc/cc",
-         "cc/cc conflict with cran::cc, to be installed"))
+    list("Can't install dependency bb",
+         "Can't install dependency cc/cc",
+         "cc/cc conflicts with cran::cc, to be installed"))
 })

--- a/tests/testthat/test-solve.R
+++ b/tests/testthat/test-solve.R
@@ -155,7 +155,7 @@ test_that("integration test", {
   sol <- r$solve()
   expect_equal(sol$status, "FAILED")
   expect_true("cli" %in% sol$failures$package)
-  expect_output(print(sol), "Cannot install.*cran::cli")
+  expect_output(print(sol), "cran::cli:")
 })
 
 test_that("failure in non-needed package is ignored", {

--- a/tests/testthat/test-type-cran.R
+++ b/tests/testthat/test-type-cran.R
@@ -57,8 +57,7 @@ test_that("failed resolution", {
                         dependencies = FALSE))
 
   expect_true(all(res$status == "FAILED"))
-  expect_match(conditionMessage(res$error[[1]]),
-               "Cannot find standard ref")
+  expect_match(conditionMessage(res$error[[1]]), "Can't find package")
 
   ## Existing package, non-existing version
 
@@ -89,7 +88,7 @@ test_that("failed resolution, multiple", {
 
   expect_true("FAILED" %in% res$status)
   err <- res$error[res$ref != "cran::crayon"][[1]]
-  expect_match(conditionMessage(err), "Cannot find standard ref")
+  expect_match(conditionMessage(err), "Can't find package")
 
 })
 


### PR DESCRIPTION
Tweak failure error messages

* Remove duplicated "cannot install"
* Use single line when possible
* Add with after conflicts
* Use standard bullets

Before:

```
Cannot install packages:
  x Cannot install `dplyr`.
    - Conflicts tidyverse/dplyr
  x Cannot install `tidyverse/dplyr`.
    - Conflicts dplyr 
```

After:

```
Error: Cannot install packages:                                            
* dplyr: Conflicts with tidyverse/dplyr
* tidyverse/dplyr: Conflicts with dplyr
```