### PR TITLE
Use shorter paths, warn for long paths on win

### DIFF
--- a/R/install-progress-bar.R
+++ b/R/install-progress-bar.R
@@ -1,13 +1,13 @@
 
 #' @importFrom cli symbol cli_alert_success cli_alert_danger
 
-alert <- function(type, msg, .envir = parent.frame()) {
+alert <- function(type, msg, ..., .envir = parent.frame()) {
   switch (
     type,
-    success = cli_alert_success(msg, .envir = .envir),
-    info = cli_alert_info(msg, .envir = .envir),
-    warning = cli_alert_warning(msg, .envir = .envir),
-    danger = cli_alert_danger(msg, .envir = .envir)
+    success = cli_alert_success(msg, ..., .envir = .envir),
+    info = cli_alert_info(msg, ..., .envir = .envir),
+    warning = cli_alert_warning(msg, ..., .envir = .envir),
+    danger = cli_alert_danger(msg, ..., .envir = .envir)
   )
 }
 


### PR DESCRIPTION
We use shorter paths now, they are practically as short as
possible using the proper R temporary directory. We also
detect paths that are too long, and warn for them.

For the record, we cannot currently use a junction with a
shorter path, because pkgbuild calls `normalizePath()` on
the package directory path, and this resolves junctions.
But it also does not make too much sense to use them, since
they cannot be much shorter than the current paths.

Creating a drive for the path would make it the shortest
possible, but this is rather messy to do programmatically.
We would need to look for the existing drives to choose a
letter, it would be easy to leave the drive behind on a crash,
etc. So we are not doing this.

Closes https://github.com/r-lib/pak/issues/252