### PR TITLE
Sugars for local packages:

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ License: MIT + file LICENSE
 LazyData: true
 URL: https://github.com/r-lib/pkgdepends#readme
 BugReports: https://github.com/r-lib/pkgdepends/issues
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.1.9000
 Roxygen: list(
     markdown = TRUE,
     packages = "roxygenlabs",

--- a/R/parse-remotes.R
+++ b/R/parse-remotes.R
@@ -132,6 +132,16 @@ remote_type_rx <- function() {
   )
 }
 
+local_rx <- function() {
+  typed <- "local::(?<path>.*)"
+  sugar <- "(?<path>(?:/|\\\\|~|[.]/|[.]\\\\|[.]$).*)"
+  paste0(
+    "^",
+    "(?|", typed, "|", sugar, ")",
+    "$"
+  )
+}
+
 #' @importFrom rematch2 re_match
 
 type_default_parse <- function(refs, ...) {
@@ -148,6 +158,7 @@ get_remote_types <- function(refs) {
   types[types == "" & grepl(standard_rx(), refs, perl = TRUE)] <- "standard"
   types[types == "" & grepl(github_rx(), refs, perl = TRUE)] <- "github"
   types[types == "" & grepl(github_url_rx(), refs, perl = TRUE)] <- "github"
+  types[types == "" & grepl(local_rx(), refs, perl = TRUE)] <- "local"
 
   if (any(bad <- types == "")) {
     stop("Can't parse remotes: ", paste(refs[bad], collapse = ", "))

--- a/R/rx.R
+++ b/R/rx.R
@@ -30,7 +30,7 @@ pkg_rx <- function() {
     type_bioc        = standard_rx("bioc"),
     type_standard    = standard_rx("standard"),
     type_github      = github_rx(),
-    type_local       = type_local_rx(),
+    type_local       = local_rx(),
     type_deps        = type_deps_rx(),
     type_installed   = type_installed_rx(),
     github_username  = github_username_rx(),

--- a/R/type-local.R
+++ b/R/type-local.R
@@ -3,8 +3,8 @@
 ### API
 
 parse_remote_local <- function(specs, config, ...) {
-  parsed_specs <- re_match(specs, type_local_rx())
-  parsed_specs$ref <- parsed_specs$.text
+  parsed_specs <- re_match(specs, local_rx())
+  parsed_specs$ref <- paste0("local::", parsed_specs$path)
   cn <- setdiff(colnames(parsed_specs), c(".match", ".text"))
   parsed_specs <- parsed_specs[, cn]
   parsed_specs$type <- "local"
@@ -45,18 +45,6 @@ download_remote_local <- function(resolution, target, target_tree, config,
 }
 
 satisfy_remote_local <- function(resolution, candidate, config, ...) {
-    ## TODO: we can probably do better than this
-    FALSE
-  }
-
-## ----------------------------------------------------------------------
-## Internal functions
-
-type_local_rx <- function() {
-  paste0(
-    "^",
-    "(?:local::)",
-    "(?<path>.*)",
-    "$"
-  )
+  ## TODO: we can probably do better than this
+  FALSE
 }

--- a/man/pkg_refs.Rd
+++ b/man/pkg_refs.Rd
@@ -125,9 +125,20 @@ A path that refers to a package file built with \verb{R CMD build}, or a
 directory that contains a package. Full syntax:\preformatted{local::<path>
 }
 
+For brevity, you can omit the \verb{local::} prefix, if you specify an
+absolute path, a path from the user’s home directory, starting with \code{~},
+or a relative path starting with \verb{./} or \verb{.\\}.
+
+A single dot (\code{"."}) is considered to be a local package in the current
+working directory.
+
 Examples:\preformatted{local::/foo/bar/package_1.0.0.tar.gz
 local::/foo/bar/pkg
 local::.
+/absolute/path/package_1.0.0.tar.gz
+~/path/from/home
+./relative/path
+.
 }
 }
 

--- a/tests/testthat/test-parse-remotes.R
+++ b/tests/testthat/test-parse-remotes.R
@@ -279,3 +279,30 @@ test_that("default parse function", {
     remote_types = list(foo = list(), foo2 = list()))
   expect_identical(res, res2)
 })
+
+test_that("parse_pkg_refs, local", {
+
+  cases <- list(
+    list("local::path", "path"),
+    list("local::/path", "/path"),
+    list("local::~/path", "~/path"),
+    list("local::./path", "./path"),
+    list("local::\\path", "\\path"),
+    list("/path", "/path"),
+    list("~/path", "~/path"),
+    list("./path", "./path"),
+    list(".\\path", ".\\path"),
+    list("\\path", "\\path"),
+    list(".", ".")
+  )
+
+  for (c in cases) {
+    expect_equal(
+      parse_pkg_ref(c[[1]]),
+      structure(
+        list(path = c[[2]], ref = paste0("local::", c[[2]]), type = "local"),
+        class = c("remote_ref_local", "remote_ref", "list")
+      )
+    )
+  }
+})

--- a/tools/doc/pkg-refs.Rmd
+++ b/tools/doc/pkg-refs.Rmd
@@ -134,11 +134,22 @@ directory that contains a package. Full syntax:
 local::<path>
 ````
 
+For brevity, you can omit the `local::` prefix, if you specify an
+absolute path, a path from the user's home directory, starting with `~`,
+or a relative path starting with `./` or `.\\`.
+
+A single dot (`"."`) is considered to be a local package in the current
+working directory.
+
 Examples:
 ```
 local::/foo/bar/package_1.0.0.tar.gz
 local::/foo/bar/pkg
 local::.
+/absolute/path/package_1.0.0.tar.gz
+~/path/from/home
+./relative/path
+.
 ```
 
 ## Installed packages:


### PR DESCRIPTION
```
/absolute/path
./relative/path
~/path/from/home
.
```

and the Windows versions as well with \.