### PR TITLE
Put locally built packages into the cache, GH uses them

### DIFF
--- a/R/download-progress-bar.R
+++ b/R/download-progress-bar.R
@@ -195,7 +195,7 @@ pkgplan__update_progress_bar <- function(bar, idx, event, data) {
           bar$what$current[idx] + bar$what$filesize[idx]
         bar$what$current[idx] <- bar$what$filesize[idx]
       }
-    } else if (data$download_status %in% c("Had", "Current")) {
+    } else if (grepl("^(Had|Current)", data$download_status)) {
       bar$what$status[idx] <- "had"
       bar$what$current[idx] <- 0L
       bar$what$need[idx] <- 0L

--- a/R/download.R
+++ b/R/download.R
@@ -172,7 +172,7 @@ download_remote <- function(res, config, cache, which,
           && !file.exists(target_tree)) {
         stop("Failed to download ", res$type, " package ", res$package)
       }
-      if (!identical(s, "Had") && !identical(s, "Got") &&
+      if (!grepl("^Had", s) && !identical(s, "Got") &&
           !identical(s, "Current")) s <- "Got"
       dlres <- res
       dlres$fulltarget <- target

--- a/R/pkg-installation.R
+++ b/R/pkg-installation.R
@@ -428,7 +428,9 @@ pkg_installation_proposal <- R6::R6Class(
     install = function() {
       plan <- private$plan$get_install_plan()
       nw <- get_num_workers()
-      install_package_plan(plan, lib = private$library, num_workers = nw)
+      cache <- get_private(private$plan)$cache$package
+      install_package_plan(plan, lib = private$library, num_workers = nw,
+                           cache = cache)
     },
 
     #' Create an installation plan for the downloaded packages.

--- a/R/solve.R
+++ b/R/solve.R
@@ -741,7 +741,8 @@ pkgplan_install_plan <- function(self, private, downloads) {
   direct <- sol$direct |
     (sol$type == "installed" & sol$package %in% direct_packages)
 
-  binary = sol$platform != "source"
+  had <- paste("Had", current_r_platform())
+  binary = sol$platform != "source" | sol$download_status == had
   vignettes <- ! binary & ! sol$type %in% c("cran", "bioc", "standard") &
     private$config$`build-vignettes`
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -108,7 +108,7 @@ make_dl_status <- function(status, url, target, bytes, error = NULL) {
   } else if (status == "Failed") {
     obj$error <- error
 
-  } else if (status == "Had") {
+  } else if (grepl("^Had", status)) {
     obj$bytes <- as.double(bytes)
   }
 

--- a/man/install_package_plan.Rd
+++ b/man/install_package_plan.Rd
@@ -4,7 +4,12 @@
 \alias{install_package_plan}
 \title{Perform a package installation plan}
 \usage{
-install_package_plan(plan, lib = .libPaths()[[1]], num_workers = 1)
+install_package_plan(
+  plan,
+  lib = .libPaths()[[1]],
+  num_workers = 1,
+  cache = NULL
+)
 }
 \arguments{
 \item{plan}{Package plan object, a data frame, see
@@ -13,6 +18,8 @@ install_package_plan(plan, lib = .libPaths()[[1]], num_workers = 1)
 \item{lib}{Library directory to install to.}
 
 \item{num_workers}{Number of worker processes to use.}
+
+\item{cache}{Package cache to use, or \code{NULL}.}
 }
 \value{
 Information about the installation process.

--- a/tests/testthat/test-install-zip.R
+++ b/tests/testthat/test-install-zip.R
@@ -1,7 +1,7 @@
 
 test_that("make_unzip_process", {
 
-  zipfile <- system.file(package = .packageName, "tools", "xxx.zip")
+  zipfile <- system.file(package = "pkgdepends", "tools", "xxx.zip")
   mkdirp(tmp <- tempfile())
   on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
 


### PR DESCRIPTION
When installing packages, built source and binary packages
are added to the cache.

GitHub remotes check for the latest 1) binary, 2) source,
3) package tree archive in the cache.

With these changes switching between GH and CRAN package
versions is very quick.

If you need to re-compile/re-download a package, you can
 use the `?source`/`?nocache` parameters.

Closes https://github.com/r-lib/pak/issues/77.