### PR TITLE
Better handling of platforms

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Imports:
     jsonlite,
     lpSolve,
     pkgbuild (>= 1.0.2),
-    pkgcache (>= 1.2.0),
+    pkgcache (>= 1.2.2.9000),
     prettyunits (>= 1.1.1),
     processx (>= 3.4.2),
     ps,
@@ -54,6 +54,7 @@ Suggests:
     spelling,
     testthat,
     webfakes
+Remotes: r-lib/pkgcache@feature/platforms
 Config/testthat/edition: 3
 Config/Needs/website:
     pkgdown

--- a/R/utils.R
+++ b/R/utils.R
@@ -165,46 +165,6 @@ omit_cols <- function(df, omit) {
   }
 }
 
-get_all_package_dirs <- function(platforms, rversions) {
-  minors <- unique(get_minor_r_version(rversions))
-  res <- lapply(platforms, function(pl) {
-    if (pl == "source") {
-      cbind("source", "*", "src/contrib")
-
-    } else if (pl == "windows") {
-      cbind("windows", minors, paste0("bin/windows/contrib/", minors))
-
-    } else if (pl == "macos") {
-      res1 <- lapply(minors, function(v) {
-        if (package_version(v) <= "2.15") {
-          cbind("macos", v, paste0("bin/macosx/leopard/contrib/", v))
-        } else if (package_version(v) == "3.0") {
-          cbind("macos", v, paste0("bin/macosx/contrib/", v))
-        } else if (package_version(v) <= "3.2") {
-          cbind("macos", v, paste0(c("bin/macosx/contrib/",
-                                     "bin/macosx/mavericks/contrib/"), v))
-        } else if (package_version(v) == "3.3") {
-          cbind("macos", v, paste0("bin/macosx/mavericks/contrib/", v))
-        } else {
-          cbind("macos", v, paste0("bin/macosx/el-capitan/contrib/", v))
-        }
-      })
-      do.call(rbind, res1)
-    }
-  })
-
-  mat <- do.call(rbind, res)
-  colnames(mat) <- c("platform", "rversion", "contriburl")
-  res <- as_tibble(mat)
-  res$prefix <- paste0(
-    "/",
-    ifelse(res$rversion == "*", "*", paste0("R-", res$rversion)),
-    "/", res$platform, "/"
-  )
-
-  res
-}
-
 same_sha <- function(s1, s2) {
   assert_that(is_string(s1), is_string(s2))
   len <- min(nchar(s1), nchar(s2))

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -197,18 +197,6 @@ test_that("omit_cols", {
   expect_identical(omit_cols(df, c("a", "b", "c")), df[, c(), drop = FALSE])
 })
 
-test_that("get_all_package_dirs", {
-  res <- get_all_package_dirs(
-    unique(c(current_r_platform(), "source")), current_r_version())
-
-  expect_s3_class(res, "tbl_df")
-  expect_equal(
-    colnames(res),
-    c("platform", "rversion", "contriburl", "prefix"))
-  expect_gte(nrow(res), 1)
-  expect_true(all(sapply(res, is.character)))
-})
-
 test_that("same_sha", {
   expect_true(same_sha("badcafe", "b"))
   expect_true(same_sha("b", "badcafe"))


### PR DESCRIPTION
In the spirit of https://github.com/r-lib/pkgcache/pull/64

Use meaningful platform names. Support Windows archs better, to make sure that all dependencies of a package have the required arch(s) installed.