### PR TITLE
Fix packaging step for GitHub installs with a subdirectory

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -38,7 +38,6 @@ jobs:
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      CI_GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
 
     steps:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -19,7 +19,6 @@ jobs:
       group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      CI_GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v3
 

--- a/R/install-plan.R
+++ b/R/install-plan.R
@@ -466,6 +466,12 @@ start_task_package_build <- function(state, task) {
   ## tree was downloaded from GitHub
   tree_dir <- task$args$tree_dir
   dir_tree_dir <- dir(tree_dir)
+
+  subdir <- state$plan$remote[[pkgidx]]$subdir
+  if (is.character(subdir) && !identical(subdir, "")) {
+    dir_tree_dir <- file.path(dir_tree_dir, subdir)
+  }
+
   if (! "DESCRIPTION" %in% dir_tree_dir && length(dir_tree_dir) == 1 &&
       "DESCRIPTION" %in% dir(file.path(tree_dir, dir_tree_dir))) {
     tree_dir <- file.path(tree_dir, dir_tree_dir)

--- a/R/install-plan.R
+++ b/R/install-plan.R
@@ -462,19 +462,21 @@ start_task_package_build <- function(state, task) {
   pkgidx <- task$args$pkgidx
   pkg <- state$plan$package[pkgidx]
 
-  ## The actual package might be in a subdirectory, e.g. when the
-  ## tree was downloaded from GitHub
-  tree_dir <- task$args$tree_dir
-  dir_tree_dir <- dir(tree_dir)
-
-  subdir <- state$plan$remote[[pkgidx]]$subdir
-  if (is.character(subdir) && !identical(subdir, "")) {
-    dir_tree_dir <- file.path(dir_tree_dir, subdir)
+  # GH (and similar) packages might be in a subdirectory
+  subdir <- c(state$plan$metadata[[pkgidx]]["RemoteSubdir"])[1]
+  if (is.null(subdir) || is.na(subdir)) {
+    subdir <- "."
   }
 
-  if (! "DESCRIPTION" %in% dir_tree_dir && length(dir_tree_dir) == 1 &&
-      "DESCRIPTION" %in% dir(file.path(tree_dir, dir_tree_dir))) {
-    tree_dir <- file.path(tree_dir, dir_tree_dir)
+  # The actual package might be in a subdirectory of the tarball,
+  # e.g. when the tree was downloaded from GitHub. So the package is
+  # either in tree_dir/subdir or tree_dir/something/subdir
+  root_dir <- task$args$tree_dir
+  pkg_dir <- file.path(root_dir, subdir)
+  dir_root_dir <- dir(root_dir)
+
+  if (! "DESCRIPTION" %in% dir_root_dir && length(dir_root_dir) == 1) {
+    pkg_dir <- file.path(root_dir, dir_root_dir, subdir)
   }
 
   vignettes <- state$plan$vignettes[pkgidx]
@@ -482,7 +484,7 @@ start_task_package_build <- function(state, task) {
   lib <- state$config$lib
 
   task$args$phase <- "build"
-  px <- make_build_process(tree_dir, pkg, create_temp_dir(), lib, vignettes,
+  px <- make_build_process(pkg_dir, pkg, create_temp_dir(), lib, vignettes,
                            needscompilation, binary = FALSE,
                            cmd_args = NULL)
   worker <- list(id = get_worker_id(), task = task, process = px,

--- a/R/type-github.R
+++ b/R/type-github.R
@@ -76,6 +76,8 @@ download_remote_github <- function(resolution, target, target_tree,
       .list = c(if (need_vignettes) c(vignettes = TRUE)))
 
     if (nrow(hit)) {
+      # in case there is a leftover tree there
+      unlink(target_tree, recursive = TRUE)
       return(paste("Had", ptfm)) # TODO: untested currently
     }
   }
@@ -92,6 +94,8 @@ download_remote_github <- function(resolution, target, target_tree,
       .list = c(if (need_vignettes) c(vignettes = TRUE)))
     if (nrow(hit)) {
       "!DEBUG found GH `resolution$ref`@`sha` in the cache"
+      # in case there is a leftover tree there
+      unlink(target_tree, recursive = TRUE)
       return("Had")
     }
   }
@@ -114,6 +118,7 @@ download_remote_github <- function(resolution, target, target_tree,
   "!DEBUG Need to download GH package `resolution$ref`@`sha`"
   urls <- resolution$sources[[1]]
   rel_zip <- paste0(rel_target, "-t")
+  unlink(target, recursive = TRUE)
   type_github_download_repo(urls, target_tree, rel_zip, sha, package, cache,
                             on_progress, nocache)$
     then(function() {

--- a/R/type-github.R
+++ b/R/type-github.R
@@ -66,6 +66,9 @@ download_remote_github <- function(resolution, target, target_tree,
   nocache <- is_true_param(resolution$params[[1]], "nocache")
   source <- is_true_param(resolution$params[[1]], "source")
 
+  # in case there is a leftover package/tree here
+  unlink(c(target, target_tree), recursive = TRUE)
+
   ## 1. Check for a binary package
 
   if (!nocache && !source) {
@@ -76,8 +79,6 @@ download_remote_github <- function(resolution, target, target_tree,
       .list = c(if (need_vignettes) c(vignettes = TRUE)))
 
     if (nrow(hit)) {
-      # in case there is a leftover tree there
-      unlink(target_tree, recursive = TRUE)
       return(paste("Had", ptfm)) # TODO: untested currently
     }
   }
@@ -94,8 +95,6 @@ download_remote_github <- function(resolution, target, target_tree,
       .list = c(if (need_vignettes) c(vignettes = TRUE)))
     if (nrow(hit)) {
       "!DEBUG found GH `resolution$ref`@`sha` in the cache"
-      # in case there is a leftover tree there
-      unlink(target_tree, recursive = TRUE)
       return("Had")
     }
   }
@@ -118,7 +117,6 @@ download_remote_github <- function(resolution, target, target_tree,
   "!DEBUG Need to download GH package `resolution$ref`@`sha`"
   urls <- resolution$sources[[1]]
   rel_zip <- paste0(rel_target, "-t")
-  unlink(target, recursive = TRUE)
   type_github_download_repo(urls, target_tree, rel_zip, sha, package, cache,
                             on_progress, nocache)$
     then(function() {

--- a/tests/testthat/test-install-plan.R
+++ b/tests/testthat/test-install-plan.R
@@ -123,3 +123,139 @@ test_that("add_recursive_dependencies", {
   expect_snapshot(add_recursive_dependencies(plan))
   expect_snapshot(add_recursive_dependencies(plan)$dependencies)
 })
+
+test_that("install package from GH", {
+  setup_fake_apps()
+  setup_fake_gh_app()
+  pkgcache::pkg_cache_delete_files()
+
+  lib <- withr::local_tempdir()
+  config <- list(library = lib)
+  pkg <- new_pkg_installation_proposal("r-lib/crayon", config = config)
+  suppressMessages(pkg$solve())
+  suppressMessages(pkg$download())
+  suppressMessages(pkg$install())
+  expect_true(file.exists(file.path(lib, "crayon")))
+
+  # check cache state, must have a tree, a source and a binary package
+  check_cache <- function() {
+    cache <- pkgcache::pkg_cache_list()
+    expect_equal(nrow(cache), 3L)
+    expect_true(any(cache$package == "crayon" & !cache$built))
+    expect_true(any(
+      cache$package == "crayon" & cache$built & cache$platform == "source"
+    ))
+    expect_true(any(
+      cache$package == "crayon" & cache$built & cache$platform != "source"
+    ))
+  }
+  check_cache()
+
+  # install from cache, binary is selected
+  remove.packages("crayon", lib = lib)
+  pkg <- new_pkg_installation_proposal("r-lib/crayon", config = config)
+  suppressMessages(pkg$solve())
+  suppressMessages(pkg$download())
+  expect_equal(
+    pkg$get_downloads()$download_status,
+    paste("Had", current_r_platform())
+  )
+  suppressMessages(pkg$install())
+  expect_true(file.exists(file.path(lib, "crayon")))
+
+  # cache is updated with the binary
+  check_cache()
+
+  # install from cache, no binary, source package is selected
+  remove.packages("crayon", lib = lib)
+  pkgcache::pkg_cache_delete_files(
+    built = TRUE, platform = current_r_platform()
+  )
+  pkg <- new_pkg_installation_proposal("r-lib/crayon", config = config)
+  suppressMessages(pkg$solve())
+  suppressMessages(pkg$download())
+  expect_equal(pkg$get_downloads()$download_status, "Had")
+  suppressMessages(pkg$install())
+  expect_true(file.exists(file.path(lib, "crayon")))
+
+  # install from cache, no binary, no source, tree is selected
+  remove.packages("crayon", lib = lib)
+  pkgcache::pkg_cache_delete_files(built = TRUE)
+  pkg <- new_pkg_installation_proposal("r-lib/crayon", config = config)
+  suppressMessages(pkg$solve())
+  suppressMessages(pkg$download())
+  expect_equal(pkg$get_downloads()$download_status, "Had")
+  suppressMessages(pkg$install())
+  expect_true(file.exists(file.path(lib, "crayon")))
+
+  # cache is updated with the source and binary
+  check_cache()
+})
+
+test_that("install package from GH, in subdir", {
+  setup_fake_apps()
+  setup_fake_gh_app()
+  pkgcache::pkg_cache_delete_files()
+
+  lib <- withr::local_tempdir()
+  config <- list(library = lib)
+  pkg <- new_pkg_installation_proposal("wesm/feather/R", config = config)
+  suppressMessages(pkg$solve())
+  suppressMessages(pkg$download())
+  suppressMessages(pkg$install())
+  expect_true(file.exists(file.path(lib, "feather")))
+
+  # check cache state, must have a tree, a source and a binary package
+  check_cache <- function() {
+    cache <- pkgcache::pkg_cache_list()
+    expect_equal(nrow(cache), 3L)
+    expect_true(any(cache$package == "feather" & !cache$built))
+    expect_true(any(
+      cache$package == "feather" & cache$built & cache$platform == "source"
+    ))
+    expect_true(any(
+      cache$package == "feather" & cache$built & cache$platform != "source"
+    ))
+  }
+  check_cache()
+
+  # install from cache, binary is selected
+  remove.packages("feather", lib = lib)
+  pkg <- new_pkg_installation_proposal("wesm/feather/R", config = config)
+  suppressMessages(pkg$solve())
+  suppressMessages(pkg$download())
+  expect_equal(
+    pkg$get_downloads()$download_status,
+    paste("Had", current_r_platform())
+  )
+  suppressMessages(pkg$install())
+  expect_true(file.exists(file.path(lib, "feather")))
+
+  # cache is updated with the binary
+  check_cache()
+
+  # install from cache, no binary, source package is selected
+  remove.packages("feather", lib = lib)
+  pkgcache::pkg_cache_delete_files(
+    built = TRUE, platform = current_r_platform()
+  )
+  pkg <- new_pkg_installation_proposal("wesm/feather/R", config = config)
+  suppressMessages(pkg$solve())
+  suppressMessages(pkg$download())
+  expect_equal(pkg$get_downloads()$download_status, "Had")
+  suppressMessages(pkg$install())
+  expect_true(file.exists(file.path(lib, "feather")))
+
+  # install from cache, no binary, no source, tree is selected
+  remove.packages("feather", lib = lib)
+  pkgcache::pkg_cache_delete_files(built = TRUE)
+  pkg <- new_pkg_installation_proposal("wesm/feather/R", config = config)
+  suppressMessages(pkg$solve())
+  suppressMessages(pkg$download())
+  expect_equal(pkg$get_downloads()$download_status, "Had")
+  suppressMessages(pkg$install())
+  expect_true(file.exists(file.path(lib, "feather")))
+
+  # cache is updated with the source and binary
+  check_cache()
+})

--- a/tests/testthat/test-pkg-lockfile.R
+++ b/tests/testthat/test-pkg-lockfile.R
@@ -23,3 +23,72 @@ test_that("new_pkg_installation_plan", {
   expect_error(plan$set_solve_policy())
   expect_error(plan$solve())
 })
+
+test_that("install package from GH, in subdir", {
+  setup_fake_apps()
+  setup_fake_gh_app()
+  pkgcache::pkg_cache_delete_files()
+
+  lib <- withr::local_tempdir()
+  config <- list(library = lib)
+  pkg <- new_pkg_installation_proposal("wesm/feather/R", config = config)
+  suppressMessages(pkg$solve())
+  lock <- file.path(withr::local_tempdir(), "pkg.lock")
+  suppressMessages(pkg$create_lockfile(lock))
+
+  plan <- new_pkg_installation_plan(lock, config = config)
+  suppressMessages(plan$download())
+  suppressMessages(plan$install())
+  expect_true(file.exists(file.path(lib, "feather")))
+
+  # check cache state, must have a tree, a source and a binary package
+  check_cache <- function() {
+    cache <- pkgcache::pkg_cache_list()
+    expect_equal(nrow(cache), 3L)
+    expect_true(any(cache$package == "feather" & !cache$built))
+    expect_true(any(
+      cache$package == "feather" & cache$built & cache$platform == "source"
+    ))
+    expect_true(any(
+      cache$package == "feather" & cache$built & cache$platform != "source"
+    ))
+  }
+  check_cache()
+
+  # install from cache, binary is selected
+  remove.packages("feather", lib = lib)
+  plan <- new_pkg_installation_plan(lock, config = config)
+  suppressMessages(plan$download())
+  expect_equal(
+    plan$get_downloads()$download_status,
+    paste("Had", current_r_platform())
+  )
+  suppressMessages(plan$install())
+  expect_true(file.exists(file.path(lib, "feather")))
+
+  # cache is updated with the binary
+  check_cache()
+
+  # install from cache, no binary, source package is selected
+  remove.packages("feather", lib = lib)
+  pkgcache::pkg_cache_delete_files(
+    built = TRUE, platform = current_r_platform()
+  )
+  plan <- new_pkg_installation_plan(lock, config = config)
+  suppressMessages(plan$download())
+  expect_equal(plan$get_downloads()$download_status, "Had")
+  suppressMessages(plan$install())
+  expect_true(file.exists(file.path(lib, "feather")))
+
+  # install from cache, no binary, no source, tree is selected
+  remove.packages("feather", lib = lib)
+  pkgcache::pkg_cache_delete_files(built = TRUE)
+  plan <- new_pkg_installation_plan(lock, config = config)
+  suppressMessages(plan$download())
+  expect_equal(plan$get_downloads()$download_status, "Had")
+  suppressMessages(plan$install())
+  expect_true(file.exists(file.path(lib, "feather")))
+
+  # cache is updated with the source and binary
+  check_cache()
+})


### PR DESCRIPTION
Fixes https://github.com/r-lib/pak/issues/431 locally (but I'm rather unfamiliar with the consequences this might have for other types of package installs).

If it's helpful, my local tests were:

```r
pak::pkg_install("apache/arrow-nanoarrow/r")
```

...and

```r
pak::pkg_install("paleolimbot/narrow")
```