### PR TITLE
Handle explicit package names in local:: and url:: dependencies

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,10 @@
 * `pkg_name_check()` now works again, it needed a fix after changes at
   https://crandb.r-pkg.org.
 
+* Explicit package names in local and URL package sources, as in
+  `package=local::...` or `package=url::...` are now parsed correctly in
+  dependencies.
+
 # pkgdepends 0.3.2
 
 * The `?ignore` parameter works correctly now.

--- a/R/parse-remotes.R
+++ b/R/parse-remotes.R
@@ -102,8 +102,8 @@ github_url_rx <- function() {
     "(?:(?<package>", package_name_rx(), ")=)?",
     ## Optional remote type
     "(?:github::)?",
-    ## Optional protocol
-    "(?:(?:https?://)|(?:ssh://(?:[^@]+@)?)?)",
+    ## Protocol
+    "(?:(?:https?://)|(?:(?:ssh://|[^@]+@)))",
     ## Servername
     "(?:[^/:]+)[/:]",
     ## Username
@@ -137,6 +137,8 @@ local_rx <- function() {
   sugar <- "(?<path>(?:/|\\\\|~|[.]/|[.]\\\\|[.]$).*)"
   paste0(
     "^",
+    ## Optional package name
+    "(?:(?<package>", package_name_rx(), ")=)?",
     "(?|", typed, "|", sugar, ")",
     "$"
   )

--- a/man/pkgdepends-package.Rd
+++ b/man/pkgdepends-package.Rd
@@ -63,51 +63,22 @@ pd$solve()
 pd$draw()
 }\if{html}{\out{</div>}}
 
-\if{html}{\out{<div class="sourceCode">}}\preformatted{#> r-lib/pkgcache 1.2.2.9000 [new][bld][cmp]
-#> +-assertthat 0.2.1 [new]
-#> +-callr 3.7.0 [new]
-#> | +-processx 3.5.2 [new]
-#> | | +-ps 1.6.0 [new]
-#> | | \-R6 2.5.1 [new]
+\if{html}{\out{<div class="sourceCode">}}\preformatted{#> r-lib/pkgcache 2.0.3.9000 [new][bld][cmp][dl] (unknown size)
+#> +-callr 3.7.3 [new]
+#> | +-processx 3.8.0 [new]
+#> | | +-ps 1.7.2 [new]
+#> | | \-R6 2.5.1 [new][dl] (82.52 kB)
 #> | \-R6
-#> +-cli 3.1.0 [new]
-#> | \-glue 1.5.0 [new]
-#> +-curl 4.3.2 [new]
-#> +-digest 0.6.28 [new]
-#> +-filelock 1.0.2 [new]
-#> +-glue
-#> +-jsonlite 1.7.2 [new]
-#> +-prettyunits 1.1.1 [new]
-#> +-R6
+#> +-cli 3.4.1 [new]
+#> +-curl 4.3.3 [new][dl] (756.97 kB)
+#> +-filelock 1.0.2 [new][dl] (29.09 kB)
+#> +-jsonlite 1.8.3 [new]
+#> +-prettyunits 1.1.1 [new][dl] (34.70 kB)
 #> +-processx
-#> +-rappdirs 0.3.3 [new]
-#> +-rlang 0.4.12 [new]
-#> +-tibble 3.1.6 [new]
-#> | +-ellipsis 0.3.2 [new]
-#> | | \-rlang
-#> | +-fansi 0.5.0 [new]
-#> | +-lifecycle 1.0.1 [new]
-#> | | +-glue
-#> | | \-rlang
-#> | +-magrittr 2.0.1 [new]
-#> | +-pillar 1.6.4 [new]
-#> | | +-cli
-#> | | +-crayon 1.4.2 [new]
-#> | | +-ellipsis
-#> | | +-fansi
-#> | | +-lifecycle
-#> | | +-rlang
-#> | | +-utf8 1.2.2 [new]
-#> | | \-vctrs 0.3.8 [new]
-#> | |   +-ellipsis
-#> | |   +-glue
-#> | |   \-rlang
-#> | +-pkgconfig 2.0.3 [new]
-#> | +-rlang
-#> | \-vctrs
-#> \-uuid 1.0-3 [new]
+#> +-R6
+#> \-rappdirs 0.3.3 [new][dl] (46.80 kB)
 #> 
-#> Key:  [new] new | [bld] build | [cmp] compile
+#> Key:  [new] new | [dl] download | [bld] build | [cmp] compile
 }\if{html}{\out{</div>}}
 
 See the \code{\link{pkg_deps}} class for details.

--- a/tests/testthat/_snaps/package-names.md
+++ b/tests/testthat/_snaps/package-names.md
@@ -1,0 +1,56 @@
+# local dep needs name
+
+    Code
+      p$stop_for_solution_error()
+    Error <rlib_error_3_0>
+      ! Could not solve package dependencies:
+      * local::./pkg1: ! pkgdepends resolution error for local::./pkg1.
+      Caused by error:
+      ! Cannot determine package name for 1 package: "local::./pkg2".
+      i Maybe you need to add a `<packagename>=` prefix?
+
+---
+
+    Code
+      p$get_solution()
+    Output
+      <pkg_solution>
+      + result: OK
+      + refs:
+        - local::./pkg1
+      + constraints (3):
+        - select pkg1 exactly once
+        - select pkg2 at most once
+        - local::./pkg1 depends on pkg2=local::./pkg2: version pkg2=local::./pkg2 1.0.0
+      + solution:
+        - local::./pkg1
+        - pkg2=local::./pkg2
+
+# url dep needs name
+
+    Code
+      p$stop_for_solution_error()
+    Error <rlib_error_3_0>
+      ! Could not solve package dependencies:
+      * local::./pkg2: ! pkgdepends resolution error for local::./pkg2.
+      Caused by error:
+      ! Cannot determine package name for 1 package: "url::http://127.0.0.1:<port>//src/contrib/Archive/pkg1/pkg1_0.9.0.tar.gz".
+      i Maybe you need to add a `<packagename>=` prefix?
+
+---
+
+    Code
+      p$get_solution()
+    Output
+      <pkg_solution>
+      + result: OK
+      + refs:
+        - local::./pkg2
+      + constraints (3):
+        - select pkg2 exactly once
+        - select pkg1 at most once
+        - local::./pkg2 depends on pkg1=url::http://127.0.0.1:<port>//src/contrib/Archive/pkg1/pkg1_0.9.0.tar.gz: version pkg1=url::http://127.0.0.1:<port>//src/contrib/Archive/pkg1/pkg1_0.9.0.tar.gz 0.9.0
+      + solution:
+        - local::./pkg2
+        - pkg1=url::http://127.0.0.1:<port>//src/contrib/Archive/pkg1/pkg1_0.9.0.tar.gz
+

--- a/tests/testthat/_snaps/parse-remotes.md
+++ b/tests/testthat/_snaps/parse-remotes.md
@@ -6,3 +6,254 @@
       ! Cannot parse package: my_package.
       i See `?pkgdepends::pkg_refs()` for supported package sources.
 
+# explicit package names
+
+    Code
+      parse_pkg_ref("package=user/notpackage")
+    Output
+      $package
+      [1] "package"
+      
+      $username
+      [1] "user"
+      
+      $repo
+      [1] "notpackage"
+      
+      $subdir
+      [1] ""
+      
+      $commitish
+      [1] ""
+      
+      $pull
+      [1] ""
+      
+      $release
+      [1] ""
+      
+      $ref
+      [1] "package=user/notpackage"
+      
+      $type
+      [1] "github"
+      
+      $params
+      character(0)
+      
+      attr(,"class")
+      [1] "remote_ref_github" "remote_ref"        "list"             
+    Code
+      parse_pkg_ref("package=user/notpackage@tag")
+    Output
+      $package
+      [1] "package"
+      
+      $username
+      [1] "user"
+      
+      $repo
+      [1] "notpackage"
+      
+      $subdir
+      [1] ""
+      
+      $commitish
+      [1] "tag"
+      
+      $pull
+      [1] ""
+      
+      $release
+      [1] ""
+      
+      $ref
+      [1] "package=user/notpackage@tag"
+      
+      $type
+      [1] "github"
+      
+      $params
+      character(0)
+      
+      attr(,"class")
+      [1] "remote_ref_github" "remote_ref"        "list"             
+    Code
+      parse_pkg_ref("package=github::user/notpackage@tag")
+    Output
+      $package
+      [1] "package"
+      
+      $username
+      [1] "user"
+      
+      $repo
+      [1] "notpackage"
+      
+      $subdir
+      [1] ""
+      
+      $commitish
+      [1] "tag"
+      
+      $pull
+      [1] ""
+      
+      $release
+      [1] ""
+      
+      $ref
+      [1] "package=github::user/notpackage@tag"
+      
+      $type
+      [1] "github"
+      
+      $params
+      character(0)
+      
+      attr(,"class")
+      [1] "remote_ref_github" "remote_ref"        "list"             
+    Code
+      parse_pkg_ref("package=local::/abs/path")
+    Output
+      $package
+      [1] "package"
+      
+      $path
+      [1] "/abs/path"
+      
+      $ref
+      [1] "package=local::/abs/path"
+      
+      $type
+      [1] "local"
+      
+      $params
+      character(0)
+      
+      attr(,"class")
+      [1] "remote_ref_local" "remote_ref"       "list"            
+    Code
+      parse_pkg_ref("package=local::rel/path")
+    Output
+      $package
+      [1] "package"
+      
+      $path
+      [1] "rel/path"
+      
+      $ref
+      [1] "package=local::rel/path"
+      
+      $type
+      [1] "local"
+      
+      $params
+      character(0)
+      
+      attr(,"class")
+      [1] "remote_ref_local" "remote_ref"       "list"            
+    Code
+      parse_pkg_ref("package=local::~/home/path")
+    Output
+      $package
+      [1] "package"
+      
+      $path
+      [1] "~/home/path"
+      
+      $ref
+      [1] "package=local::~/home/path"
+      
+      $type
+      [1] "local"
+      
+      $params
+      character(0)
+      
+      attr(,"class")
+      [1] "remote_ref_local" "remote_ref"       "list"            
+    Code
+      parse_pkg_ref("package=/abs/path")
+    Output
+      $package
+      [1] "package"
+      
+      $path
+      [1] "/abs/path"
+      
+      $ref
+      [1] "package=local::/abs/path"
+      
+      $type
+      [1] "local"
+      
+      $params
+      character(0)
+      
+      attr(,"class")
+      [1] "remote_ref_local" "remote_ref"       "list"            
+    Code
+      parse_pkg_ref("package=./rel/path")
+    Output
+      $package
+      [1] "package"
+      
+      $path
+      [1] "./rel/path"
+      
+      $ref
+      [1] "package=local::./rel/path"
+      
+      $type
+      [1] "local"
+      
+      $params
+      character(0)
+      
+      attr(,"class")
+      [1] "remote_ref_local" "remote_ref"       "list"            
+    Code
+      parse_pkg_ref("package=~/home/path")
+    Output
+      $package
+      [1] "package"
+      
+      $path
+      [1] "~/home/path"
+      
+      $ref
+      [1] "package=local::~/home/path"
+      
+      $type
+      [1] "local"
+      
+      $params
+      character(0)
+      
+      attr(,"class")
+      [1] "remote_ref_local" "remote_ref"       "list"            
+    Code
+      parse_pkg_ref("package=url::https://example.com/p1.tar.gz")
+    Output
+      $package
+      [1] "package"
+      
+      $url
+      [1] "https://example.com/p1.tar.gz"
+      
+      $ref
+      [1] "package=url::https://example.com/p1.tar.gz"
+      
+      $type
+      [1] "url"
+      
+      $hash
+      [1] "abc44e36b1d7392a347beee661d5342b"
+      
+      $params
+      character(0)
+      
+      attr(,"class")
+      [1] "remote_ref_url" "remote_ref"     "list"          
+

--- a/tests/testthat/_snaps/type-local.md
+++ b/tests/testthat/_snaps/type-local.md
@@ -52,6 +52,9 @@
       
       $remote
       $remote[[1]]
+      $package
+      [1] NA
+      
       $path
       [1] "fixtures/foobar_1.0.0.tar.gz"
       
@@ -163,6 +166,9 @@
       
       $remote
       $remote[[1]]
+      $package
+      [1] NA
+      
       $path
       [1] "foobar_1.0.0.tar.gz"
       
@@ -227,4 +233,47 @@
     Message <cliMessage>
       i Getting 1 pkg with unknown size
       x Failed to download foobar 1.0.0 (source)
+
+# satisfy
+
+    Code
+      # different package name, FALSE
+      satisfy_remote_local(list(package = "foo"), list(package = "bar"))
+    Output
+      [1] FALSE
+      attr(,"reason")
+      [1] "Package names differ"
+    Code
+      # different type is bad
+      satisfy_remote_local(list(package = "foo", remote = list(list(package = NA_character_)),
+      path = "/tmp/foo"), list(type = "notgood", package = "foo", path = "/tmp/foo"))
+    Output
+      [1] FALSE
+      attr(,"reason")
+      [1] "Package source mismatch"
+    Code
+      # any package name is good, good
+      satisfy_remote_local(list(package = "foo", remote = list(list(package = NA_character_,
+        path = "/tmp/foo"))), list(type = "local", package = "foo", remote = list(
+        list(path = "/tmp/foo"))))
+    Output
+      [1] TRUE
+    Code
+      # requested a different package, bad
+      satisfy_remote_local(list(package = "foo", remote = list(list(package = "bar",
+        path = "/tmp/foo"))), list(type = "local", package = "foo", remote = list(
+        list(package = "bar", path = "/tmp/foo"))))
+    Output
+      [1] FALSE
+      attr(,"reason")
+      [1] "Requested package bar but got foo"
+    Code
+      # different paths are bad
+      satisfy_remote_local(list(package = "foo", remote = list(list(package = "foo",
+        path = "/tmp/foo"))), list(type = "local", package = "foo", remote = list(
+        list(package = "foo", path = "/tmp/foo2"))))
+    Output
+      [1] FALSE
+      attr(,"reason")
+      [1] "Paths differ"
 

--- a/tests/testthat/test-package-names.R
+++ b/tests/testthat/test-package-names.R
@@ -1,0 +1,78 @@
+
+test_that("local dep needs name", {
+  setup_fake_apps()
+
+  withr::local_dir(tmp <- withr::local_tempdir())
+
+  mkdirp("pkg1")
+  file.create("pkg1/NAMESPACE")
+  writeLines(c(
+    "Package: pkg1",
+    "Version: 1.0.0",
+    "License: MIT",
+    "Imports: pkg2",
+    "Remotes: local::./pkg2"
+  ), "pkg1/DESCRIPTION")
+
+  mkdirp("pkg2")
+  file.create("pkg2/NAMESPACE")
+  writeLines(c(
+    "Package: pkg2",
+    "Version: 1.0.0",
+    "License: MIT"
+  ), "pkg2/DESCRIPTION")
+
+  mkdirp("lib")
+  config <- list(library = file.path(tmp, "lib"))
+  p <- new_pkg_installation_proposal("./pkg1", config = config)
+  p$solve()
+  expect_snapshot(
+    error = TRUE,
+    p$stop_for_solution_error(),
+    transform = transform_no_srcref
+  )
+
+  desc::desc_set(Remotes = "pkg2=local::./pkg2", file = "pkg1")
+  p <- new_pkg_installation_proposal("./pkg1", config = config)
+  p$solve()
+  expect_snapshot(p$get_solution())
+})
+
+test_that("url dep needs name", {
+  setup_fake_apps()
+
+  withr::local_dir(tmp <- withr::local_tempdir())
+
+  mkdirp("pkg2")
+  file.create("pkg2/NAMESPACE")
+
+  url <- paste0(
+    fake_cran$url(),
+    "/src/contrib/Archive/pkg1/pkg1_0.9.0.tar.gz"
+  )
+  writeLines(c(
+    "Package: pkg2",
+    "Version: 1.0.0",
+    "License: MIT",
+    "Imports: pkg1",
+    paste0("Remotes: url::", url)
+  ), "pkg2/DESCRIPTION")
+
+  mkdirp("lib")
+  config <- list(library = file.path(tmp, "lib"))
+  p <- new_pkg_installation_proposal("./pkg2", config = config)
+  p$solve()
+  expect_snapshot(
+    error = TRUE,
+    p$stop_for_solution_error(),
+    transform = function(x) transform_no_srcref(transform_local_port(x))
+  )
+
+  desc::desc_set(Remotes = paste0("pkg1=url::", url), file = "pkg2")
+  p <- new_pkg_installation_proposal("./pkg2", config = config)
+  p$solve()
+  expect_snapshot(
+    p$get_solution(),
+    transform = transform_local_port
+  )
+})

--- a/tests/testthat/test-parse-remotes.R
+++ b/tests/testthat/test-parse-remotes.R
@@ -240,7 +240,8 @@ test_that("parse_pkg_refs, local", {
     expect_equal(
       parse_pkg_ref(c[[1]]),
       structure(
-        list(path = c[[2]], ref = paste0("local::", c[[2]]), type = "local",
+        list(package = NA_character_, path = c[[2]],
+             ref = paste0("local::", c[[2]]), type = "local",
              params = character()),
         class = c("remote_ref_local", "remote_ref", "list")
       )
@@ -278,4 +279,21 @@ test_that("parameters", {
     wo$params <- c[[3]]
     expect_equal(wi, wo)
   }
+})
+
+test_that("explicit package names", {
+  expect_snapshot({
+    parse_pkg_ref("package=user/notpackage")
+    parse_pkg_ref("package=user/notpackage@tag")
+    parse_pkg_ref("package=github::user/notpackage@tag")
+
+    parse_pkg_ref("package=local::/abs/path")
+    parse_pkg_ref("package=local::rel/path")
+    parse_pkg_ref("package=local::~/home/path")
+    parse_pkg_ref("package=/abs/path")
+    parse_pkg_ref("package=./rel/path")
+    parse_pkg_ref("package=~/home/path")
+
+    parse_pkg_ref("package=url::https://example.com/p1.tar.gz")
+  })
 })

--- a/tests/testthat/test-type-local.R
+++ b/tests/testthat/test-type-local.R
@@ -185,8 +185,66 @@ test_that("download_remote error", {
 })
 
 test_that("satisfy", {
-  ## Always FALSE, independently of arguments
-  expect_false(satisfy_remote_local())
+  expect_snapshot({
+    "different package name, FALSE"
+    satisfy_remote_local(
+      list(package = "foo"),
+      list(package = "bar")
+    )
+
+    "different type is bad"
+    satisfy_remote_local(
+      list(
+        package = "foo",
+        remote = list(list(package = NA_character_)),
+        path = "/tmp/foo"
+      ),
+      list(
+        type = "notgood",
+        package = "foo",
+        path = "/tmp/foo"
+      )
+    )
+
+    "any package name is good, good"
+    satisfy_remote_local(
+      list(
+        package = "foo",
+        remote = list(list(package = NA_character_, path = "/tmp/foo"))
+      ),
+      list(
+        type = "local",
+        package = "foo",
+        remote = list(list(path = "/tmp/foo"))
+      )
+    )
+
+    "requested a different package, bad"
+    satisfy_remote_local(
+      list(
+        package = "foo",
+        remote = list(list(package = "bar", path = "/tmp/foo"))
+      ),
+      list(
+        type = "local",
+        package = "foo",
+        remote = list(list(package = "bar", path = "/tmp/foo"))
+      )
+    )
+
+    "different paths are bad"
+    satisfy_remote_local(
+      list(
+        package = "foo",
+        remote = list(list(package = "foo", path = "/tmp/foo"))
+      ),
+      list(
+        type = "local",
+        package = "foo",
+        remote = list(list(package = "foo", path = "/tmp/foo2"))
+      )
+    )
+  })
 })
 
 test_that("installedok", {


### PR DESCRIPTION
They are now required and they are parsed correctly.