### PR TITLE
Bundle multiple apt-get commands

### DIFF
--- a/R/sysreqs.R
+++ b/R/sysreqs.R
@@ -132,6 +132,8 @@ sysreqs_install <- function(sysreqs_cmds, config = NULL) {
     callback <- function(x, ...) invisible()
   }
 
+  cmds <- compact_cmds(cmds)
+
   output <- lapply(cmds, function(cmd) {
     if (sudo) {
       sh <- "sudo"                                               # nocov
@@ -158,5 +160,18 @@ detect_linux <- function() {
   list(
     distribution = plt[["distribution"]] %||% "unknown",
     release = plt[["release"]] %||% "unknown"
+  )
+}
+
+compact_cmds <- function(x) {
+  rx <- "^(echo )?apt-get install -y ([a-z0-9-]+)$"
+  if (length(x) == 0 || !all(grepl(rx, x))) {
+    return(x)
+  }
+
+  paste0(
+    gsub(rx, "\\1", x[[1]]),
+    "apt-get install -y ",
+    paste(gsub(rx, "\\2", x), collapse = " ")
   )
 }

--- a/tests/testthat/_snaps/sysreqs.md
+++ b/tests/testthat/_snaps/sysreqs.md
@@ -141,8 +141,7 @@
       sysreqs_install(srq)
     Message <cliMessage>
       i Installing system requirements
-      i Executing `sh -c echo apt-get install -y libssl-dev`
-      i Executing `sh -c echo apt-get install -y libcurl4-openssl-dev`
+      i Executing `sh -c echo apt-get install -y libssl-dev libcurl4-openssl-dev`
 
 ---
 

--- a/tests/testthat/_snaps/sysreqs.md
+++ b/tests/testthat/_snaps/sysreqs.md
@@ -141,6 +141,15 @@
       sysreqs_install(srq)
     Message <cliMessage>
       i Installing system requirements
+      i Executing `sh -c echo apt-get install -y libssl-dev`
+      i Executing `sh -c echo apt-get install -y libcurl4-openssl-dev`
+
+---
+
+    Code
+      sysreqs_install(srq)
+    Message <cliMessage>
+      i Installing system requirements
       i Executing `sh -c echo apt-get install -y default-jdk`
       i Executing `sh -c echo apt-get install -y libcurl4-openssl-dev`
       i Executing `sh -c echo R CMD javareconf`

--- a/tests/testthat/_snaps/sysreqs.md
+++ b/tests/testthat/_snaps/sysreqs.md
@@ -190,3 +190,24 @@
       [1] "unknown"
       
 
+# compact_cmds
+
+    Code
+      compact_cmds(character())
+    Output
+      character(0)
+    Code
+      compact_cmds(c("apt-get install -y libssl-dev"))
+    Output
+      [1] "apt-get install -y libssl-dev"
+    Code
+      compact_cmds(c("apt-get install -y libssl-dev",
+        "apt-get install -y libcurl4-openssl-dev"))
+    Output
+      [1] "apt-get install -y libssl-dev libcurl4-openssl-dev"
+    Code
+      compact_cmds(c("echo apt-get install -y libssl-dev",
+        "echo apt-get install -y libcurl4-openssl-dev"))
+    Output
+      [1] "echo apt-get install -y libssl-dev libcurl4-openssl-dev"
+

--- a/tests/testthat/helper-apps.R
+++ b/tests/testthat/helper-apps.R
@@ -450,6 +450,9 @@ new_sysreqs_app <- function() {
           install_scripts = list("apt-get install -y default-jdk"),
           post_install = list(list(command = "R CMD javareconf"))
         ),
+        "openssl" = list(
+          install_scripts = list("apt-get install -y libssl-dev")
+        ),
         "libcurl" = list(
           install_scripts = list("apt-get install -y libcurl4-openssl-dev")
         )

--- a/tests/testthat/test-sysreqs.R
+++ b/tests/testthat/test-sysreqs.R
@@ -88,3 +88,20 @@ test_that("detect_linux", {
   )
   expect_snapshot(detect_linux())
 })
+
+test_that("compact_cmds", {
+  expect_snapshot({
+    compact_cmds(character())
+    compact_cmds(c(
+      "apt-get install -y libssl-dev"
+    ))
+    compact_cmds(c(
+      "apt-get install -y libssl-dev",
+      "apt-get install -y libcurl4-openssl-dev"
+    ))
+    compact_cmds(c(
+      "echo apt-get install -y libssl-dev",
+      "echo apt-get install -y libcurl4-openssl-dev"
+    ))
+  })
+})

--- a/tests/testthat/test-sysreqs.R
+++ b/tests/testthat/test-sysreqs.R
@@ -59,6 +59,9 @@ test_that("sysreqs_install", {
 
   # not verbose
   withr::local_envvar(PKG_SYSREQS_VERBOSE = "false")
+  srq <- sysreqs_resolve("libcurl and openssl", "ubuntu", "22.04")
+  expect_snapshot(sysreqs_install(srq))
+
   srq <- sysreqs_resolve("java and also libcurl", "ubuntu", "22.04")
   expect_snapshot(sysreqs_install(srq))
 


### PR DESCRIPTION
Only if all commands are of the form `apt-get install -y` . Could be done a bit better by grouping sequences of such commands.

No tests so far, I can't run tests locally.

Follow-up to https://github.com/r-lib/pak/pull/440#issuecomment-1349670206.