### PR TITLE
Simplify compaction of apt-get calls

### DIFF
--- a/R/sysreqs.R
+++ b/R/sysreqs.R
@@ -121,6 +121,8 @@ sysreqs_install <- function(sysreqs_cmds, config = NULL) {
   # TODO: fix 'R' commands (e.g. `R CMD javareconf`) to call the current
   # version of R and not the one on the PATH
 
+  cmds <- compact_cmds(cmds)
+
   if (dry_run) cmds <- paste("echo", cmds)
 
   if (verbose) {
@@ -131,8 +133,6 @@ sysreqs_install <- function(sysreqs_cmds, config = NULL) {
   } else {
     callback <- function(x, ...) invisible()
   }
-
-  cmds <- compact_cmds(cmds)
 
   output <- lapply(cmds, function(cmd) {
     if (sudo) {
@@ -164,14 +164,13 @@ detect_linux <- function() {
 }
 
 compact_cmds <- function(x) {
-  rx <- "^(echo )?apt-get install -y ([a-z0-9-]+)$"
+  rx <- "^apt-get install -y ([a-z0-9-]+)$"
   if (length(x) == 0 || !all(grepl(rx, x))) {
     return(x)
   }
 
   paste0(
-    gsub(rx, "\\1", x[[1]]),
     "apt-get install -y ",
-    paste(gsub(rx, "\\2", x), collapse = " ")
+    paste(gsub(rx, "\\1", x), collapse = " ")
   )
 }

--- a/tests/testthat/_snaps/sysreqs.md
+++ b/tests/testthat/_snaps/sysreqs.md
@@ -205,9 +205,4 @@
         "apt-get install -y libcurl4-openssl-dev"))
     Output
       [1] "apt-get install -y libssl-dev libcurl4-openssl-dev"
-    Code
-      compact_cmds(c("echo apt-get install -y libssl-dev",
-        "echo apt-get install -y libcurl4-openssl-dev"))
-    Output
-      [1] "echo apt-get install -y libssl-dev libcurl4-openssl-dev"
 

--- a/tests/testthat/test-sysreqs.R
+++ b/tests/testthat/test-sysreqs.R
@@ -99,9 +99,5 @@ test_that("compact_cmds", {
       "apt-get install -y libssl-dev",
       "apt-get install -y libcurl4-openssl-dev"
     ))
-    compact_cmds(c(
-      "echo apt-get install -y libssl-dev",
-      "echo apt-get install -y libcurl4-openssl-dev"
-    ))
   })
 })


### PR DESCRIPTION
Simpler regex, don't need to deal with `echo` when compacting.