### PR TITLE
Fix solver for R version requirements

### DIFF
--- a/R/solve.R
+++ b/R/solve.R
@@ -584,6 +584,7 @@ pkgplan_i_lp_prefer_new_binaries <- function(lp) {
         pkgs$platform != "source" &
         pkgs$type %in% c("cran", "bioc", "standard")
     )
+    whp <- setdiff(whp, lp$ruled_out)
     v <- package_version(pkgs$version[whp])
     ruled_out <- c(ruled_out, whp[v != max(v)])
   }


### PR DESCRIPTION
In the new-binaries check we should ignore
the packages that were ruled out for other
reasons.

Fixes #534.