### PR TITLE
Add missing space in download info message 

### DIFF
--- a/R/download-progress-bar.R
+++ b/R/download-progress-bar.R
@@ -385,8 +385,8 @@ pkgplan__done_progress_bar <- function(bar) {
   } else if (err == 0) {
     cli_alert_success(
       paste0(
-        "Downloaded {dld} package{?s} {.size ({bts})} ",
-        if (bar$show_time) "in {.time {dt}}"
+        "Downloaded {dld} package{?s} {.size ({bts})}",
+        if (bar$show_time) " in {.time {dt}}"
       )
     )
   } else {

--- a/R/download-progress-bar.R
+++ b/R/download-progress-bar.R
@@ -385,7 +385,7 @@ pkgplan__done_progress_bar <- function(bar) {
   } else if (err == 0) {
     cli_alert_success(
       paste0(
-        "Downloaded {dld} package{?s} {.size ({bts})}",
+        "Downloaded {dld} package{?s} {.size ({bts})} ",
         if (bar$show_time) "in {.time {dt}}"
       )
     )


### PR DESCRIPTION
r-lib/pak#535

```r
# now
 Downloaded 1 package (260.26 kB)in 1.5s    
# hopefully with this PR
 Downloaded 1 package (260.26 kB) in 1.5s    
```

Edit: thanks for the heads-up