### PR TITLE
Sending "multi_ack" in git-v1

### DIFF
--- a/R/git-protocol.R
+++ b/R/git-protocol.R
@@ -342,7 +342,7 @@ async_git_fetch_v1 <- function(url, sha, blobs) {
       "done",
       ""
     ),
-    caps = c("no-done", "no-progress", paste0("agent=", git_ua()))
+    caps = c("multi_ack" ,"no-done", "no-progress", paste0("agent=", git_ua()))
   )$then(function(reply) git_fetch_process_v1(reply, url, sha))
 }
 


### PR DESCRIPTION
I've been spending a little while trying to get pak to work with the Bank of England's locally hosted version of Azure DevOps, but I've been getting an HTTP error when pak (or more accurately pkgdepends) tries to get the target package's DESCRIPTION file. The various error messages point towards pak not advertising it's "multi_ack" support in git protocol V1.

I've tested the fix in this PR internally for the Bank's R packages and it works for us. I unfortunately can't provide a reprex, but there might be a public instance of Azure DevOps that I don't know about which could help with that.