### PR TITLE
Better platform matching in installedok()

### DIFF
--- a/R/type-bioc.R
+++ b/R/type-bioc.R
@@ -96,8 +96,7 @@ installedok_remote_bioc <- function(installed, solution, config, ...) {
     # that we are installing the same build.
     identical(installed$package, solution$package) &&
       identical(installed$version, solution$version) &&
-      (identical(installed[["platform"]], solution[["platform"]]) ||
-       identical(installed[["platform"]], "*")) &&
+      installedok_remote_standard_platform(installed, solution, config, ...) &&
       identical(installed[["built"]], solution[["built"]])
 
   } else {

--- a/R/type-cran.R
+++ b/R/type-cran.R
@@ -95,8 +95,7 @@ installedok_remote_cran <- function(installed, solution, config, ...) {
     # that we are installing the same build.
     identical(installed$package, solution$package) &&
       identical(installed$version, solution$version) &&
-      (identical(installed[["platform"]], solution[["platform"]]) ||
-       identical(installed[["platform"]], "*")) &&
+      installedok_remote_standard_platform(installed, solution, config, ...) &&
       identical(installed[["built"]], solution[["built"]])
 
   } else {

--- a/R/type-standard.R
+++ b/R/type-standard.R
@@ -113,8 +113,7 @@ installedok_remote_standard <- function(installed, solution, config, ...) {
     # the repo must match
     identical(installed$package, solution$package) &&
       identical(installed$version, solution$version) &&
-      (identical(installed[["platform"]], solution[["platform"]]) ||
-       identical(installed[["platform"]], "*")) &&
+      installedok_remote_standard_platform(installed, solution, config, ...) &&
       identical(installed$remoterepos, solution$metadata[[1]][["RemoteRepos"]])
 
   } else {
@@ -123,4 +122,14 @@ installedok_remote_standard <- function(installed, solution, config, ...) {
       identical(installed$version, solution$version) &&
       identical(installed$remoterepos, solution$metadata[[1]][["RemoteRepos"]])
   }
+}
+
+installedok_remote_standard_platform <- function(installed, solution,
+                                                 config, ...) {
+  if (identical(installed[["platform"]], solution[["platform"]])) return(TRUE)
+  if (identical(installed[["platform"]], "*")) return(TRUE)
+  if (identical(installed$remotepkgplatform, solution$platform)) return(TRUE)
+  if (is_string(solution$platform) && is_string(installed$platform) &&
+      startsWith(solution$platform, installed$platform)) return(TRUE)
+  FALSE
 }

--- a/tests/testthat/test-type-standard.R
+++ b/tests/testthat/test-type-standard.R
@@ -432,3 +432,33 @@ test_that("installedok", {
     sol
   ))
 })
+
+test_that("installedok Linux binaries", {
+  solution <- list(
+    package = "package",
+    version = "1.0.0",
+    platform = "x86_64-pc-linux-gnu-ubuntu-22.04"
+  )
+  installed <- list(
+    package = "package",
+    version = "1.0.0",
+    platform = "x86_64-pc-linux-gnu",
+    built = "R 4.3.1; x86_64-pc-linux-gnu; 2023-09-21 14:53:54 UTC; unix"
+  )
+
+  expect_true(installedok_remote_standard(installed, solution))
+
+  solution2 <- list(
+    package = "package",
+    version = "1.0.0",
+    platform = "x86_64-pc-linux-gnu-ubuntu-22.04"
+  )
+  installed2 <- list(
+    package = "package",
+    version = "1.0.0",
+    remotepkgplatform = "x86_64-pc-linux-gnu-ubuntu-22.04",
+    platform = "x86_64-pc-linux-gnu"
+  )
+
+  expect_true(installedok_remote_standard(installed2, solution2))
+})


### PR DESCRIPTION
For standard, cran and bioc packages.

Closes https://github.com/r-lib/actions/issues/759