### PR TITLE
Stop resolution multiplying rows from metadata 

### DIFF
--- a/R/resolution-df.R
+++ b/R/resolution-df.R
@@ -116,8 +116,14 @@ res_one_row_df <- function(l) {
   assert_that(is.list(l) && all_named(l))
   samp <- res_make_empty_df()[names(l)]
   bad <- vlapply(samp, is.list) & !vlapply(l, is.list)
+  # If col is isn't a list col, but is supposed to be.
+  bad_len <- vlapply(samp, is.list) & !vlapply(l, function(x) length(x) == 1)
+  # If col is supposed to be a list, but isn't length one.
+  bad <- bad | bad_len
   l[bad] <- lapply(l[bad], list)
-  as_data_frame(l)
+  out <- as_data_frame(l)
+  assert_that(nrow(out) == 1)
+  out
 }
 
 res_list_to_df <- function(reslist) {

--- a/R/type-cran.R
+++ b/R/type-cran.R
@@ -139,7 +139,7 @@ type_cran_resolve_version <- function(remote, direct, config,
 
   url_remote <- remote
   url_remote$url <- paste0(
-    config$get("cran-mirror"),
+    config$get("cran-mirror")[[1]],
     "/src/contrib/Archive/", remote$package, "/",
     remote$package, "_", remote$version, ".tar.gz"
   )
@@ -155,7 +155,7 @@ type_cran_resolve_version <- function(remote, direct, config,
 
       # Metadata for standard::, not url::
       res$metadata[["RemoteRef"]] <- remote$package
-      res$metadata[["RemoteRepos"]] <- config$get("cran-mirror")
+      res$metadata[["RemoteRepos"]] <- config$get("cran-mirror")[[1]]
       res$metadata[["RemotePkgPlatform"]] <- "source"
       res$metadata[["RemoteSha"]] <- remote$version
       res


### PR DESCRIPTION
(Fixes #379)

The metadata column was causing certain rows to recycle over the result data frame. This could happen with any list column that isn't of length one. The solution I created here is to check if the list is not already length one and to wrap it into a list if it is not.

Also added an assertion to force the output into being one row as desired.

Very happy to accept changes as you think is appropriate.