### PR TITLE
Fix RHEL platform autodetection

### DIFF
--- a/R/sysreqs.R
+++ b/R/sysreqs.R
@@ -347,8 +347,7 @@ parse_sysreqs_platform <- function(x) {
     osplt$distribution <- restpcs[1]
     osplt$version <- paste0(restpcs[-1], collapse = "-")
   }
-  if (osplt$distribution == "rhel") {
-    osplt$distribution = "redhat"
+  if (osplt$distribution == "rhel" || osplt$distribution == "redhat") {
     osplt$version = strsplit(osplt$version, "[.]")[[1]][1]
   }
   osplt

--- a/R/sysreqs.R
+++ b/R/sysreqs.R
@@ -347,9 +347,6 @@ parse_sysreqs_platform <- function(x) {
     osplt$distribution <- restpcs[1]
     osplt$version <- paste0(restpcs[-1], collapse = "-")
   }
-  if (osplt$distribution == "rhel" || osplt$distribution == "redhat") {
-    osplt$version = strsplit(osplt$version, "[.]")[[1]][1]
-  }
   osplt
 }
 

--- a/R/sysreqs.R
+++ b/R/sysreqs.R
@@ -347,6 +347,10 @@ parse_sysreqs_platform <- function(x) {
     osplt$distribution <- restpcs[1]
     osplt$version <- paste0(restpcs[-1], collapse = "-")
   }
+  if (osplt$distribution == "rhel") {
+    osplt$distribution = "redhat"
+    osplt$version = strsplit(osplt$version, "[.]")[[1]][1]
+  }
   osplt
 }
 

--- a/R/sysreqs2.R
+++ b/R/sysreqs2.R
@@ -26,6 +26,9 @@ sysreqs2_cmds <- utils::read.table(
 find_sysreqs_platform <- function(sysreqs_platform = NULL) {
   sysreqs_platform <- sysreqs_platform %||% current_config()$get("sysreqs_platform")
   plt <- parse_sysreqs_platform(sysreqs_platform)
+  if (plt$distribution == "rhel") {
+    plt$distribution = "redhat"
+  }
   idx <- which(
     sysreqs2_cmds$os == plt$os &
     sysreqs2_cmds$distribution == plt$distribution &

--- a/R/sysreqs2.R
+++ b/R/sysreqs2.R
@@ -18,6 +18,7 @@ sysreqs2_cmds <- utils::read.table(
    'Red Hat Enterprise Linux' linux   redhat       6         NA                  'yum install -y'                    rpm
    'Red Hat Enterprise Linux' linux   redhat       7         NA                  'yum install -y'                    rpm
    'Red Hat Enterprise Linux' linux   redhat       *         NA                  'dnf install -y'                    rpm
+   'Red Hat Enterprise Linux' linux   rhel         *         NA                  'dnf install -y'                    rpm
    'Fedora Linux'             linux   fedora       *         NA                  'dnf install -y'                    rpm
    'openSUSE Linux'           linux   opensuse     *         NA                  'zypper --non-interactive install'  rpm
    'SUSE Linux Enterprise'    linux   sle          *         NA                  'zypper --non-interactive install'  rpm
@@ -26,9 +27,6 @@ sysreqs2_cmds <- utils::read.table(
 find_sysreqs_platform <- function(sysreqs_platform = NULL) {
   sysreqs_platform <- sysreqs_platform %||% current_config()$get("sysreqs_platform")
   plt <- parse_sysreqs_platform(sysreqs_platform)
-  if (plt$distribution == "rhel") {
-    plt$distribution = "redhat"
-  }
   idx <- which(
     sysreqs2_cmds$os == plt$os &
     sysreqs2_cmds$distribution == plt$distribution &

--- a/R/sysreqs2.R
+++ b/R/sysreqs2.R
@@ -18,6 +18,16 @@ sysreqs2_cmds <- utils::read.table(
    'Red Hat Enterprise Linux' linux   redhat       6         NA                  'yum install -y'                    rpm
    'Red Hat Enterprise Linux' linux   redhat       7         NA                  'yum install -y'                    rpm
    'Red Hat Enterprise Linux' linux   redhat       *         NA                  'dnf install -y'                    rpm
+   'Red Hat Enterprise Linux' linux   rhel         7.0       NA                  'yum install -y'                    rpm
+   'Red Hat Enterprise Linux' linux   rhel         7.1       NA                  'yum install -y'                    rpm
+   'Red Hat Enterprise Linux' linux   rhel         7.2       NA                  'yum install -y'                    rpm
+   'Red Hat Enterprise Linux' linux   rhel         7.3       NA                  'yum install -y'                    rpm
+   'Red Hat Enterprise Linux' linux   rhel         7.4       NA                  'yum install -y'                    rpm
+   'Red Hat Enterprise Linux' linux   rhel         7.5       NA                  'yum install -y'                    rpm
+   'Red Hat Enterprise Linux' linux   rhel         7.6       NA                  'yum install -y'                    rpm
+   'Red Hat Enterprise Linux' linux   rhel         7.7       NA                  'yum install -y'                    rpm
+   'Red Hat Enterprise Linux' linux   rhel         7.8       NA                  'yum install -y'                    rpm
+   'Red Hat Enterprise Linux' linux   rhel         7.9       NA                  'yum install -y'                    rpm
    'Red Hat Enterprise Linux' linux   rhel         *         NA                  'dnf install -y'                    rpm
    'Fedora Linux'             linux   fedora       *         NA                  'dnf install -y'                    rpm
    'openSUSE Linux'           linux   opensuse     *         NA                  'zypper --non-interactive install'  rpm

--- a/tests/testthat/_snaps/sysreqs.md
+++ b/tests/testthat/_snaps/sysreqs.md
@@ -3,7 +3,7 @@
     Code
       sysreqs_platforms()
     Output
-      # A data frame: 10 x 7
+      # A data frame: 11 x 7
          name  os    distribution version update_command install_command query_command
          <chr> <chr> <chr>        <chr>   <chr>          <chr>           <chr>        
        1 Ubun~ linux ubuntu       *       apt-get -y up~ apt-get -y ins~ dpkg-query   
@@ -13,9 +13,10 @@
        5 Red ~ linux redhat       6       <NA>           yum install -y  rpm          
        6 Red ~ linux redhat       7       <NA>           yum install -y  rpm          
        7 Red ~ linux redhat       *       <NA>           dnf install -y  rpm          
-       8 Fedo~ linux fedora       *       <NA>           dnf install -y  rpm          
-       9 open~ linux opensuse     *       <NA>           zypper --non-i~ rpm          
-      10 SUSE~ linux sle          *       <NA>           zypper --non-i~ rpm          
+       8 Red ~ linux rhel         *       <NA>           dnf install -y  rpm          
+       9 Fedo~ linux fedora       *       <NA>           dnf install -y  rpm          
+      10 open~ linux opensuse     *       <NA>           zypper --non-i~ rpm          
+      11 SUSE~ linux sle          *       <NA>           zypper --non-i~ rpm          
 
 # sysreqs_db_list
 

--- a/tests/testthat/_snaps/sysreqs.md
+++ b/tests/testthat/_snaps/sysreqs.md
@@ -1,9 +1,9 @@
 # sysreqs_platforms
 
     Code
-      sysreqs_platforms()
+      print(sysreqs_platforms(), n = Inf)
     Output
-      # A data frame: 12 x 7
+      # A data frame: 22 x 7
          name  os    distribution version update_command install_command query_command
          <chr> <chr> <chr>        <chr>   <chr>          <chr>           <chr>        
        1 Ubun~ linux ubuntu       *       apt-get -y up~ apt-get -y ins~ dpkg-query   
@@ -13,11 +13,21 @@
        5 Red ~ linux redhat       6       <NA>           yum install -y  rpm          
        6 Red ~ linux redhat       7       <NA>           yum install -y  rpm          
        7 Red ~ linux redhat       *       <NA>           dnf install -y  rpm          
-       8 Red ~ linux rhel         *       <NA>           dnf install -y  rpm          
-       9 Fedo~ linux fedora       *       <NA>           dnf install -y  rpm          
-      10 open~ linux opensuse     *       <NA>           zypper --non-i~ rpm          
-      11 SUSE~ linux sle          *       <NA>           zypper --non-i~ rpm          
-      12 Alpi~ linux alpine       *       <NA>           apk add --no-c~ apk          
+       8 Red ~ linux rhel         7.0     <NA>           yum install -y  rpm          
+       9 Red ~ linux rhel         7.1     <NA>           yum install -y  rpm          
+      10 Red ~ linux rhel         7.2     <NA>           yum install -y  rpm          
+      11 Red ~ linux rhel         7.3     <NA>           yum install -y  rpm          
+      12 Red ~ linux rhel         7.4     <NA>           yum install -y  rpm          
+      13 Red ~ linux rhel         7.5     <NA>           yum install -y  rpm          
+      14 Red ~ linux rhel         7.6     <NA>           yum install -y  rpm          
+      15 Red ~ linux rhel         7.7     <NA>           yum install -y  rpm          
+      16 Red ~ linux rhel         7.8     <NA>           yum install -y  rpm          
+      17 Red ~ linux rhel         7.9     <NA>           yum install -y  rpm          
+      18 Red ~ linux rhel         *       <NA>           dnf install -y  rpm          
+      19 Fedo~ linux fedora       *       <NA>           dnf install -y  rpm          
+      20 open~ linux opensuse     *       <NA>           zypper --non-i~ rpm          
+      21 SUSE~ linux sle          *       <NA>           zypper --non-i~ rpm          
+      22 Alpi~ linux alpine       *       <NA>           apk add --no-c~ apk          
 
 # sysreqs_db_list
 

--- a/tests/testthat/test-sysreqs.R
+++ b/tests/testthat/test-sysreqs.R
@@ -1,6 +1,6 @@
 
 test_that("sysreqs_platforms", {
-  expect_snapshot(sysreqs_platforms())
+  expect_snapshot(print(sysreqs_platforms(), n = Inf))
 })
 
 test_that("sysreqs_db_list", {


### PR DESCRIPTION
https://github.com/r-lib/pak/issues/610

Can likely be done more elegantly but should go into the right direction and move things forward.

RHEL is reported as follows

```r
pak::system_r_platform()
[1] "aarch64-unknown-linux-gnu-rhel-9.4"
>

pak::system_r_platform()
[1] "x86_64-pc-linux-gnu-rhel-9.4"
>

pak::system_r_platform()
[1] "aarch64-unknown-linux-gnu-rhel-8.10"
>

pak::system_r_platform()
[1] "x86_64-pc-linux-gnu-rhel-8.10"
>
```

Given that all RH-related sysdep mappings are referenced as `"redhat"`, rewriting the respective internal mappings made most sense to me.

This change results in the following

```r
sysreqs_install_plan("curl", config = list(sysreqs_platform = "x86_64-pc-linux-gnu-rhel-8.10"))

$os
[1] "linux"

$distribution
[1] "redhat"

$version
[1] "8"

$pre_install
character(0)

$install_scripts
character(0)

$post_install
character(0)
```

Given that `"redhat-8"` and `"redhat-9"` already work as desired when handed over manually, this change should align the platform parsing for the moment. 
There might be other parts that need to be touched in addition, you might know best.