### PR TITLE
improve rockylinux 8 and 9 support (crb vs powertools)

### DIFF
--- a/inst/sysreqs/rules/chrome.json
+++ b/inst/sysreqs/rules/chrome.json
@@ -50,7 +50,24 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "rockylinux"
+          "distribution": "rockylinux",
+          "versions": ["9"]
+        }
+      ]
+    },
+    {
+      "pre_install": [
+        { "command": "dnf install -y dnf-plugins-core" },
+        { "command": "dnf config-manager --set-enabled powertoools" },
+        { "command": "dnf install -y epel-release" }
+      ],
+      "packages": ["chromium"],
+      "post_install": [],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "rockylinux",
+          "versions": ["8"]
         }
       ]
     },

--- a/inst/sysreqs/rules/eigen.json
+++ b/inst/sysreqs/rules/eigen.json
@@ -72,6 +72,11 @@
           "os": "linux",
           "distribution": "centos",
           "versions": ["8"]
+        },
+        {
+          "os": "linux",
+          "distribution": "rockylinux",
+          "versions": ["8"]
         }
       ]
     },

--- a/inst/sysreqs/rules/gdal.json
+++ b/inst/sysreqs/rules/gdal.json
@@ -108,6 +108,11 @@
           "os": "linux",
           "distribution": "centos",
           "versions": ["8"]
+        },
+        {
+          "os": "linux",
+          "distribution": "rockylinux",
+          "versions": ["8"]
         }
       ]
     },
@@ -139,7 +144,8 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "rockylinux"
+          "distribution": "rockylinux",
+          "versions": ["9"]
         }
       ]
     },

--- a/inst/sysreqs/rules/glpk.json
+++ b/inst/sysreqs/rules/glpk.json
@@ -58,17 +58,7 @@
           "os": "linux",
           "distribution": "centos",
           "versions": ["8"]
-        }
-      ]
-    },
-    {
-      "packages": ["glpk-devel"],
-      "pre_install": [
-        { "command": "dnf install -y dnf-plugins-core" },
-        { "command": "dnf config-manager --set-enabled crb" },
-        { "command": "dnf install -y epel-release" }
-      ],
-      "constraints": [
+        },
         {
           "os": "linux",
           "distribution": "rockylinux"

--- a/inst/sysreqs/rules/gpgme.json
+++ b/inst/sysreqs/rules/gpgme.json
@@ -62,20 +62,6 @@
         ]
       },
       {
-        "packages": ["gpgme-devel"],
-        "pre_install": [
-          { "command": "dnf install -y dnf-plugins-core" },
-          { "command": "dnf config-manager --set-enabled powertools" }
-        ],
-        "constraints": [
-          {
-            "os": "linux",
-            "distribution": "rockylinux",
-            "versions": ["8"]
-          }
-        ]
-      },
-      {
         "packages": ["gpgme"],
         "constraints": [
           {

--- a/inst/sysreqs/rules/gpgme.json
+++ b/inst/sysreqs/rules/gpgme.json
@@ -39,6 +39,11 @@
             "os": "linux",
             "distribution": "centos",
             "versions": ["8"]
+          },
+          {
+            "os": "linux",
+            "distribution": "rockylinux",
+            "versions": ["8"]
           }
         ]
       },
@@ -51,7 +56,22 @@
         "constraints": [
           {
             "os": "linux",
-            "distribution": "rockylinux"
+            "distribution": "rockylinux",
+            "versions": ["9"]
+          }
+        ]
+      },
+      {
+        "packages": ["gpgme-devel"],
+        "pre_install": [
+          { "command": "dnf install -y dnf-plugins-core" },
+          { "command": "dnf config-manager --set-enabled powertools" }
+        ],
+        "constraints": [
+          {
+            "os": "linux",
+            "distribution": "rockylinux",
+            "versions": ["8"]
           }
         ]
       },

--- a/inst/sysreqs/rules/grpcpp.json
+++ b/inst/sysreqs/rules/grpcpp.json
@@ -39,6 +39,21 @@
       ]
     },
     {
+      "pre_install": [
+        { "command": "yum install -y epel-release" },
+        { "command": "dnf install -y dnf-plugins-core" },
+        { "command": "dnf config-manager --set-enabled powertools" }
+      ],
+      "packages": ["grpc-devel", "pkgconf"],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "rockylinux",
+          "versions": ["8"]
+        }
+      ]
+    },
+    {
       "packages": ["grpc-devel"],
       "constraints": [
         {

--- a/inst/sysreqs/rules/gsl.json
+++ b/inst/sysreqs/rules/gsl.json
@@ -29,19 +29,11 @@
           "os": "linux",
           "distribution": "redhat",
           "versions": ["7", "8"]
-        }
-      ]
-    },
-    {
-      "packages": ["gsl-devel"],
-      "pre_install": [
-        { "command": "dnf install -y dnf-plugins-core" },
-        { "command": "dnf config-manager --set-enabled crb" }
-      ],
-      "constraints": [
+        },
         {
           "os": "linux",
-          "distribution": "rockylinux"
+          "distribution": "rockylinux",
+          "versions": ["8","9"]
         }
       ]
     },

--- a/inst/sysreqs/rules/leptonica.json
+++ b/inst/sysreqs/rules/leptonica.json
@@ -40,6 +40,11 @@
           "os": "linux",
           "distribution": "centos",
           "versions": ["8"]
+        },
+        {
+          "os": "linux",
+          "distribution": "rockylinux",
+          "versions": ["8"]
         }
       ]
     },
@@ -52,7 +57,8 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "rockylinux"
+          "distribution": "rockylinux",
+          "versions": ["9"]
         }
       ]
     },

--- a/inst/sysreqs/rules/libarchive.json
+++ b/inst/sysreqs/rules/libarchive.json
@@ -51,7 +51,22 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "rockylinux"
+          "distribution": "rockylinux",
+          "versions": ["9"]
+        }
+      ]
+    },
+    {
+      "packages": ["libarchive-devel"],
+      "pre_install": [
+        { "command": "dnf install -y dnf-plugins-core" },
+        { "command": "dnf config-manager --set-enabled powertools" }
+      ],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "rockylinux",
+          "versions": ["8"]
         }
       ]
     },

--- a/inst/sysreqs/rules/libarchive.json
+++ b/inst/sysreqs/rules/libarchive.json
@@ -39,6 +39,11 @@
           "os": "linux",
           "distribution": "centos",
           "versions": ["8"]
+        },
+        {
+          "os": "linux",
+          "distribution": "rockylinux",
+          "versions": ["8"]
         }
       ]
     },
@@ -53,20 +58,6 @@
           "os": "linux",
           "distribution": "rockylinux",
           "versions": ["9"]
-        }
-      ]
-    },
-    {
-      "packages": ["libarchive-devel"],
-      "pre_install": [
-        { "command": "dnf install -y dnf-plugins-core" },
-        { "command": "dnf config-manager --set-enabled powertools" }
-      ],
-      "constraints": [
-        {
-          "os": "linux",
-          "distribution": "rockylinux",
-          "versions": ["8"]
         }
       ]
     },

--- a/inst/sysreqs/rules/libavfilter.json
+++ b/inst/sysreqs/rules/libavfilter.json
@@ -33,7 +33,23 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "rockylinux"
+          "distribution": "rockylinux",
+          "versions": ["9"]
+        }
+      ]
+    },
+    {
+      "packages": ["libavfilter-free-devel"],
+      "pre_install": [
+        { "command": "dnf install -y dnf-plugins-core" },
+        { "command": "dnf config-manager --set-enabled powertools" },
+        { "command": "dnf install -y epel-release" }
+      ],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "rockylinux",
+          "versions": ["8"]
         }
       ]
     },

--- a/inst/sysreqs/rules/libjq.json
+++ b/inst/sysreqs/rules/libjq.json
@@ -38,7 +38,22 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "rockylinux"
+          "distribution": "rockylinux",
+          "versions": ["9"]
+        }
+      ]
+    },
+    {
+      "packages": ["jq-devel"],
+      "pre_install": [
+        { "command": "dnf install -y dnf-plugins-core" },
+        { "command": "dnf config-manager --set-enabled powertools" }
+      ],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "rockylinux",
+          "versions": ["8"]
         }
       ]
     },

--- a/inst/sysreqs/rules/libmagic.json
+++ b/inst/sysreqs/rules/libmagic.json
@@ -49,6 +49,11 @@
           "os": "linux",
           "distribution": "centos",
           "versions": ["8"]
+        },
+        {
+          "os": "linux",
+          "distribution": "rockylinux",
+          "versions": ["8"]
         }
       ]
     },
@@ -61,7 +66,8 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "rockylinux"
+          "distribution": "rockylinux",
+          "versions": ["9"]
         }
       ]
     },

--- a/inst/sysreqs/rules/libmecab.json
+++ b/inst/sysreqs/rules/libmecab.json
@@ -37,7 +37,8 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "rockylinux"
+          "distribution": "rockylinux",
+          "versions": ["9"]
         }
       ]
     },
@@ -47,6 +48,11 @@
         {
           "os": "linux",
           "distribution": "fedora"
+        },
+        {
+          "os": "linux",
+          "distribution": "rockylinux",
+          "versions": ["8"]
         }
       ]
     },
@@ -83,19 +89,6 @@
           "os": "linux",
           "distribution": "redhat",
           "versions": ["9"]
-        }
-      ]
-    },
-    {
-      "packages": ["mecab-devel"],
-      "pre_install": [
-        { "command": "dnf install -y dnf-plugins-core" },
-        { "command": "dnf config-manager --set-enabled crb" }
-      ],
-      "constraints": [
-        {
-          "os": "linux",
-          "distribution": "rockylinux"
         }
       ]
     }

--- a/inst/sysreqs/rules/libmysqlclient.json
+++ b/inst/sysreqs/rules/libmysqlclient.json
@@ -50,6 +50,11 @@
         {
           "os": "linux",
           "distribution": "fedora"
+        },
+        {
+          "os": "linux",
+          "distribution": "rockylinux",
+          "versions": ["8"]
         }
       ]
     },
@@ -62,7 +67,8 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "rockylinux"
+          "distribution": "rockylinux",
+          "versions": ["9"]
         }
       ]
     },

--- a/inst/sysreqs/rules/libprotobuf.json
+++ b/inst/sysreqs/rules/libprotobuf.json
@@ -50,6 +50,11 @@
           "os": "linux",
           "distribution": "centos",
           "versions": ["8"]
+        },
+        {
+          "os": "linux",
+          "distribution": "rockylinux",
+          "versions": ["8"]
         }
       ]
     },
@@ -71,7 +76,22 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "rockylinux"
+          "distribution": "rockylinux",
+          "versions": ["9"]
+        }
+      ]
+    },
+    {
+      "packages": ["protobuf-devel"],
+      "pre_install": [
+        { "command": "dnf install -y dnf-plugins-core" },
+        { "command": "dnf config-manager --set-enabled powertools" }
+      ],
+      "constraints": [
+        {
+          "os": "linux",
+          "distribution": "rockylinux",
+          "versions": ["8"]
         }
       ]
     },

--- a/inst/sysreqs/rules/libprotobuf.json
+++ b/inst/sysreqs/rules/libprotobuf.json
@@ -82,20 +82,6 @@
       ]
     },
     {
-      "packages": ["protobuf-devel"],
-      "pre_install": [
-        { "command": "dnf install -y dnf-plugins-core" },
-        { "command": "dnf config-manager --set-enabled powertools" }
-      ],
-      "constraints": [
-        {
-          "os": "linux",
-          "distribution": "rockylinux",
-          "versions": ["8"]
-        }
-      ]
-    },
-    {
       "packages": ["protobuf"],
       "constraints": [
         {

--- a/inst/sysreqs/rules/libsndfile.json
+++ b/inst/sysreqs/rules/libsndfile.json
@@ -44,6 +44,11 @@
           "os": "linux",
           "distribution": "centos",
           "versions": ["8"]
+        },
+        {
+          "os": "linux",
+          "distribution": "rockylinux",
+          "versions": ["8"]
         }
       ]
     },
@@ -56,7 +61,8 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "rockylinux"
+          "distribution": "rockylinux",
+          "versions": ["9"]
         }
       ]
     },

--- a/inst/sysreqs/rules/odbc.json
+++ b/inst/sysreqs/rules/odbc.json
@@ -29,6 +29,11 @@
         {
           "os": "linux",
           "distribution": "fedora"
+        },
+        {
+          "os": "linux",
+          "distribution": "rockylinux",
+          "versions": ["8"]
         }
       ]
     },
@@ -41,7 +46,8 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "rockylinux"
+          "distribution": "rockylinux",
+          "versions": ["9"]
         }
       ]
     },

--- a/inst/sysreqs/rules/opencv.json
+++ b/inst/sysreqs/rules/opencv.json
@@ -70,6 +70,11 @@
           "os": "linux",
           "distribution": "centos",
           "versions": ["8"]
+        },
+        {
+          "os": "linux",
+          "distribution": "rockylinux",
+          "versions": ["8"]
         }
       ]
     },
@@ -97,7 +102,8 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "rockylinux"
+          "distribution": "rockylinux",
+          "versions": ["9"]
         }
       ]
     },

--- a/inst/sysreqs/rules/poppler-glib.json
+++ b/inst/sysreqs/rules/poppler-glib.json
@@ -44,6 +44,11 @@
           "os": "linux",
           "distribution": "centos",
           "versions": ["8"]
+        },
+        {
+          "os": "linux",
+          "distribution": "rockylinux",
+          "versions": ["8"]
         }
       ]
     },
@@ -56,7 +61,8 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "rockylinux"
+          "distribution": "rockylinux",
+          "versions": ["9"]
         }
       ]
     },

--- a/inst/sysreqs/rules/poppler.json
+++ b/inst/sysreqs/rules/poppler.json
@@ -44,6 +44,11 @@
           "os": "linux",
           "distribution": "centos",
           "versions": ["8"]
+        },
+        {
+          "os": "linux",
+          "distribution": "rockylinux",
+          "versions": ["8"]
         }
       ]
     },
@@ -56,7 +61,8 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "rockylinux"
+          "distribution": "rockylinux",
+          "versions": ["9"]
         }
       ]
     },

--- a/inst/sysreqs/rules/protobuf-compiler.json
+++ b/inst/sysreqs/rules/protobuf-compiler.json
@@ -50,6 +50,11 @@
           "os": "linux",
           "distribution": "centos",
           "versions": ["8"]
+        },
+        {
+          "os": "linux",
+          "distribution": "rockylinux",
+          "versions": ["8"]
         }
       ]
     },
@@ -71,7 +76,8 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "rockylinux"
+          "distribution": "rockylinux",
+          "versions": ["9"]
         }
       ]
     },

--- a/inst/sysreqs/rules/redland.json
+++ b/inst/sysreqs/rules/redland.json
@@ -39,6 +39,11 @@
           "os": "linux",
           "distribution": "centos",
           "versions": ["8"]
+        },
+        {
+          "os": "linux",
+          "distribution": "rockylinux",
+          "versions": ["9"]
         }
       ]
     },
@@ -51,7 +56,8 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "rockylinux"
+          "distribution": "rockylinux",
+          "versions": ["9"]
         }
       ]
     },

--- a/inst/sysreqs/rules/suitesparse.json
+++ b/inst/sysreqs/rules/suitesparse.json
@@ -52,6 +52,11 @@
           "os": "linux",
           "distribution": "centos",
           "versions": ["8"]
+        },
+        {
+          "os": "linux",
+          "distribution": "rockylinux",
+          "versions": ["8"]
         }
       ]
     },
@@ -64,7 +69,8 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "rockylinux"
+          "distribution": "rockylinux",
+          "versions": ["9"]
         }
       ]
     },

--- a/inst/sysreqs/rules/tesseract.json
+++ b/inst/sysreqs/rules/tesseract.json
@@ -48,6 +48,11 @@
         {
           "os": "linux",
           "distribution": "centos",
+          "versions": ["8"],
+        },
+        {
+          "os": "linux",
+          "distribution": "rockylinux",
           "versions": ["8"]
         }
       ]
@@ -61,7 +66,8 @@
       "constraints": [
         {
           "os": "linux",
-          "distribution": "rockylinux"
+          "distribution": "rockylinux",
+          "versions": ["9"]
         }
       ]
     },

--- a/inst/sysreqs/rules/tesseract.json
+++ b/inst/sysreqs/rules/tesseract.json
@@ -48,7 +48,7 @@
         {
           "os": "linux",
           "distribution": "centos",
-          "versions": ["8"],
+          "versions": ["8"]
         },
         {
           "os": "linux",


### PR DESCRIPTION
Upon further exploration of the `PKG_SYSREQS_PLATFORM="redhat-X` workaround for RHEL based linux distributions, I found that in `pkgdepends` we already have some support for RockyLinux. When setting `PKG_SYSREQS_PLATFORM=rockylinux-9` everything works like a charm, however `PKG_SYSREQS_PLATFORM=rockylinux-8` fails. 

Rocky Linux 9 is using `crb` as their CodeReadyBuilder repo, while RockyLinux 8 is still using `powertools` (similar to CentOS 8). 

This PR is mainly adding support for Rocky Linux 8 and has relaxed the needed repositories for a couple of other packages.  