### PR TITLE
Fix checking for chunks to ignore in .Rnw files

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -515,7 +515,7 @@ omit_pre_post <- function(x, pre = 0, post = 0) {
   substr(x, 1L + pre, nchar(x) - post)
 }
 
-thruthy_strings <- c("true", "t", "1", "on", "yes", "on")
+truthy_strings <- c("true", "t", "1", "on", "yes")
 
 is_truthy <- function(x) {
   (is.logical(x) && length(x) >= 1 && !is.na(x[[1]]) && x[[1]]) ||

--- a/tests/testthat/fixtures/scan/ignore-test.Rnw
+++ b/tests/testthat/fixtures/scan/ignore-test.Rnw
@@ -64,4 +64,16 @@ library(good)
 library(good)
 @
 
+<<chunk1, renv.ignore = "t">>=
+library(notthis)
+@
+
+<<chunk1, eval = "off">>=
+library(notthis)
+@
+
+<<chunk1, exercise = "yes">>=
+library(notthis)
+@
+
 \end{document}


### PR DESCRIPTION
(Fixes #437)

There was a typo in the definition of "truthy_strings", which was being used to check for chunks to ignore in .Rnw files. I have added a few test cases to cover the relevant code.