### PR TITLE
Fix unused argument (env) error

### DIFF
--- a/R/zzz-pkgdepends-config.R
+++ b/R/zzz-pkgdepends-config.R
@@ -7,14 +7,14 @@ default_windows_archs <- function() {
 
 default_update_after <- function() as.difftime(24, units = "hours")
 
-env_decode_dependencies <- function(x, name) {
+env_decode_dependencies <- function(x, name, ...) {
   if (tolower(x) %in% c("yes", "true", "1", "on")) return(TRUE)
   if (tolower(x) %in% c("no", "false", "0", "off")) return(FALSE)
   if (tolower(x) == "na") return(NA)
   strsplit(x, ";", fixed = TRUE)[[1]]
 }
 
-env_decode_difftime <- function(x, name) {
+env_decode_difftime <- function(x, name, ...) {
   if (nchar(x) >= 2) {
     unit <- substr(x, nchar(x), nchar(x))
     unit <- c(s = "secs", m = "mins", h = "hours", d = "days")[unit]

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -1,0 +1,24 @@
+test_that("current_config runs without error", {
+  expect_no_error(current_config())
+})
+
+test_that("current_config runs without error when difftime config set", {
+  withr::local_envvar(PKG_SYSREQS_DB_UPDATE_TIMEOUT = "30")
+  expect_error(
+    current_config()$get("sysreqs_db_update_timeout"),
+    "Invalid time interval specification"
+  )
+  withr::local_envvar(PKG_SYSREQS_DB_UPDATE_TIMEOUT = "30s")
+  expect_equal(
+    current_config()$get("sysreqs_db_update_timeout"),
+    as.difftime(30, units = 'secs'),
+    ignore_attr = TRUE
+  )
+  withr::local_envvar(PKG_SYSREQS_DB_UPDATE_TIMEOUT = "30h")
+  expect_equal(
+    current_config()$get("sysreqs_db_update_timeout"),
+    as.difftime(30, units = "hours"),
+    ignore_attr = TRUE
+  )
+})
+stopifnot(Sys.getenv('PKG_SYSREQS_DB_UPDATE_TIMEOUT') == '')


### PR DESCRIPTION
Fixing the issue mentioned here: https://github.com/r-lib/pak/issues/755#issuecomment-2728612684

(Not the problem that https://github.com/r-lib/pak/issues/755 is about overall, but the issue that is causing the workaround to error out.)

Symptom: `current_config` results in unhelpful error `Error in rec$env_decode(envv, envvname, env): unused argument (env)` when `PKG_SYSREQS_DB_UPDATE_TIMEOUT` is set, regardless of whether the setting is valid.