### PR TITLE
Update doc to reflect pak and pkgdepends does parse version specification

### DIFF
--- a/man/pkg_refs.Rd
+++ b/man/pkg_refs.Rd
@@ -189,9 +189,6 @@ cran::forecast
 forecast@last
 forecast@current
 }\if{html}{\out{</div>}}
-
-Note: pkgdepends currently parses the version specification part
-(everything after \code{@}), but does not use it.
 }
 
 \subsection{Bioconductor packages (\verb{bioc::})}{

--- a/tools/doc/pkg-refs.Rmd
+++ b/tools/doc/pkg-refs.Rmd
@@ -187,9 +187,6 @@ forecast@last
 forecast@current
 ```
 
-Note: `r pak_or_pkgdepends()` currently parses the version specification part
-(everything after `@`), but does not use it.
-
 ### Bioconductor packages (`bioc::`)
 
 A package from Bioconductor. The syntax is the same as for CRAN packages,

--- a/tools/doc/pkg-refs.md
+++ b/tools/doc/pkg-refs.md
@@ -179,9 +179,6 @@ cran::forecast
 forecast@last
 forecast@current
 }\if{html}{\out{</div>}}
-
-Note: pak currently parses the version specification part
-(everything after \code{@}), but does not use it.
 }
 
 \subsection{Bioconductor packages (\verb{bioc::})}{


### PR DESCRIPTION
This updates the doc ([was 4/7 years old](https://github.com/r-lib/pkgdepends/blame/main/tools/doc/pkg-refs.Rmd#L190-L191)), that said pak and pkgdepends doesn't use the version specification. Caused upstream confusion and fixes [issue #837 in pak](https://github.com/r-lib/pak/issues/837).