### PR TITLE
Add accidentally omitted show_solution method to pkg_deps class

### DIFF
--- a/R/pkg-dependencies.R
+++ b/R/pkg-dependencies.R
@@ -322,7 +322,7 @@ pkg_deps <- R6::R6Class(
         if (!has_res) "(use `$resolve()` to resolve dependencies)",
         if (has_res) "(use `$get_resolution()` to see resolution results)",
         if (!has_sol) "(use `$solve()` to solve dependencies)",
-        if (has_sol) "(use `$show_solution()` to see the dependencies",
+        if (has_sol) "(use `$show_solution()` to see the dependencies)",
         if (has_sol) "(use `$get_solution()` to see the full solution results)",
         if (has_sol && !sol_err) "(use `$draw()` to draw the dependency tree)"
       )

--- a/R/pkg-dependencies.R
+++ b/R/pkg-dependencies.R
@@ -236,6 +236,24 @@ pkg_deps <- R6::R6Class(
     get_solution = function() private$plan$get_solution(),
 
     #' @description
+    #' Show the solution of the package dependencies. This is a formatted
+    #' list of packages that will be installed.
+    #'
+    #' @param key Whether to print the key for the symbols used in the
+    #'   output. Default is `FALSE`.
+    #'
+    #' @return
+    #' The solution object, invisibly.
+    #'
+    #' @examplesIf pkgdepends:::is_online()
+    #' # Method show_solution()
+    #' pd <- new_pkg_deps("pkgload")
+    #' pd$solve()
+    #' pd$show_solution()
+
+    show_solution = function(key = FALSE) private$plan$show_solution(key),
+
+    #' @description
     #' Error if the dependency solver failed to find a consistent set of
     #' packages that can be installed together.
     #'

--- a/man/pkg_deps.Rd
+++ b/man/pkg_deps.Rd
@@ -95,6 +95,12 @@ pd$solve()
 pd$get_solution()
 \dontshow{\}) # examplesIf}
 \dontshow{if (pkgdepends:::is_online()) withAutoprint(\{ # examplesIf}
+# Method show_solution()
+pd <- new_pkg_deps("pkgload")
+pd$solve()
+pd$show_solution()
+\dontshow{\}) # examplesIf}
+\dontshow{if (pkgdepends:::is_online()) withAutoprint(\{ # examplesIf}
 # Method stop_for_solution_error()
 # This is an error, because the packages conflict:
 pd <- new_pkg_deps(
@@ -138,6 +144,7 @@ pd
 \item \href{#method-pkg_deps-set_solve_policy}{\code{pkg_deps$set_solve_policy()}}
 \item \href{#method-pkg_deps-solve}{\code{pkg_deps$solve()}}
 \item \href{#method-pkg_deps-get_solution}{\code{pkg_deps$get_solution()}}
+\item \href{#method-pkg_deps-show_solution}{\code{pkg_deps$show_solution()}}
 \item \href{#method-pkg_deps-stop_for_solution_error}{\code{pkg_deps$stop_for_solution_error()}}
 \item \href{#method-pkg_deps-draw}{\code{pkg_deps$draw()}}
 \item \href{#method-pkg_deps-format}{\code{pkg_deps$format()}}
@@ -325,6 +332,28 @@ Returns the solution of the package dependencies.
 \subsection{Returns}{
 A \link{pkg_solution_result} object, which is a list. See
 \link{pkg_solution_result} for details.
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-pkg_deps-show_solution"></a>}}
+\if{latex}{\out{\hypertarget{method-pkg_deps-show_solution}{}}}
+\subsection{Method \code{show_solution()}}{
+Show the solution of the package dependencies. This is a formatted
+list of packages that will be installed.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{pkg_deps$show_solution(key = FALSE)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{key}}{Whether to print the key for the symbols used in the
+output. Default is \code{FALSE}.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+The solution object, invisibly.
 }
 }
 \if{html}{\out{<hr>}}


### PR DESCRIPTION
I think you have accidentally omitted this method. This adds it.

Currently if I run the following from the CRAN version I obtain an error.

``` r
library(pkgdepends)
pd <- new_pkg_deps("r-lib/pkgcache")
pd$solve()
#> ℹ Loading metadata database
#> ✔ Loading metadata database ... done
#> 
pd$show_solution()
#> Error:
#> ! attempt to apply non-function
```

<sup>Created on 2026-05-19 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

<details style="margin-bottom:10px;">

<summary>

Session info
</summary>

``` r
sessioninfo::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value
#>  version  R version 4.6.0 (2026-04-24)
#>  os       macOS Tahoe 26.5
#>  system   aarch64, darwin23
#>  ui       X11
#>  language (EN)
#>  collate  en_US.UTF-8
#>  ctype    en_US.UTF-8
#>  tz       Europe/London
#>  date     2026-05-19
#>  pandoc   3.9.0.2 @ /opt/homebrew/bin/ (via rmarkdown)
#>  quarto   1.9.37 @ /usr/local/bin/quarto
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package     * version date (UTC) lib source
#>  cli           3.6.6   2026-04-09 [1] CRAN (R 4.6.0)
#>  crayon        1.5.3   2024-06-20 [1] CRAN (R 4.6.0)
#>  curl          7.1.0   2026-04-22 [1] CRAN (R 4.6.0)
#>  debugme       1.2.0   2024-04-25 [1] CRAN (R 4.6.0)
#>  desc          1.4.3   2023-12-10 [1] CRAN (R 4.6.0)
#>  digest        0.6.39  2025-11-19 [1] CRAN (R 4.6.0)
#>  evaluate      1.0.5   2025-08-27 [1] CRAN (R 4.6.0)
#>  fastmap       1.2.0   2024-05-15 [1] CRAN (R 4.6.0)
#>  filelock      1.0.3   2023-12-11 [1] CRAN (R 4.6.0)
#>  fs            2.1.0   2026-04-18 [1] CRAN (R 4.6.0)
#>  glue          1.8.1   2026-04-17 [1] CRAN (R 4.6.0)
#>  htmltools     0.5.9   2025-12-04 [1] CRAN (R 4.6.0)
#>  jsonlite      2.0.0   2025-03-27 [1] CRAN (R 4.6.0)
#>  knitr         1.51    2025-12-20 [1] CRAN (R 4.6.0)
#>  lifecycle     1.0.5   2026-01-08 [1] CRAN (R 4.6.0)
#>  lpSolve       5.6.23  2024-12-14 [1] CRAN (R 4.6.0)
#>  otel          0.2.0   2025-08-29 [1] CRAN (R 4.6.0)
#>  pillar        1.11.1  2025-09-17 [1] CRAN (R 4.6.0)
#>  pkgcache      2.2.5   2026-04-09 [1] CRAN (R 4.6.0)
#>  pkgdepends  * 0.9.1   2026-04-09 [1] CRAN (R 4.6.0)
#>  processx      3.9.0   2026-04-22 [1] CRAN (R 4.6.0)
#>  R6            2.6.1   2025-02-15 [1] CRAN (R 4.6.0)
#>  reprex        2.1.1   2024-07-06 [1] CRAN (R 4.6.0)
#>  rlang         1.2.0   2026-04-06 [1] CRAN (R 4.6.0)
#>  rmarkdown     2.31    2026-03-26 [1] CRAN (R 4.6.0)
#>  rstudioapi    0.18.0  2026-01-16 [1] CRAN (R 4.6.0)
#>  sessioninfo   1.2.3   2025-02-05 [1] CRAN (R 4.6.0)
#>  vctrs         0.7.3   2026-04-11 [1] CRAN (R 4.6.0)
#>  withr         3.0.2   2024-10-28 [1] CRAN (R 4.6.0)
#>  xfun          0.57    2026-03-20 [1] CRAN (R 4.6.0)
#>  yaml          2.3.12  2025-12-10 [1] CRAN (R 4.6.0)
#> 
#>  [1] /Library/Frameworks/R.framework/Versions/4.6/Resources/library
#>  * ── Packages attached to the search path.
#> 
#> ──────────────────────────────────────────────────────────────────────────────
```

</details>

With this fix we get what I think is the expected output.

``` r
library(pkgdepends)
pd <- new_pkg_deps("r-lib/pkgcache")
pd$solve()
#> ℹ Loading metadata database
#> ✔ Loading metadata database ... done
#> 
pd$show_solution()
#> + callr      3.7.6       ⬇
#> + cli        3.6.6      🔧 ⬇
#> + curl       7.1.0      🔧 ⬇
#> + filelock   1.0.3      🔧 ⬇
#> + jsonlite   2.0.0      🔧 ⬇
#> + pkgcache   2.2.5.9000 👷🏽‍♀️🔧 (GitHub: 56fd0d8)
#> + processx   3.9.0      🔧 ⬇
#> + ps         1.9.3      🔧 ⬇
#> + R6         2.6.1       ⬇
```

<sup>Created on 2026-05-19 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

<details style="margin-bottom:10px;">

<summary>

Session info
</summary>

``` r
sessioninfo::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value
#>  version  R version 4.6.0 (2026-04-24)
#>  os       macOS Tahoe 26.5
#>  system   aarch64, darwin23
#>  ui       X11
#>  language (EN)
#>  collate  en_US.UTF-8
#>  ctype    en_US.UTF-8
#>  tz       Europe/London
#>  date     2026-05-19
#>  pandoc   3.9.0.2 @ /opt/homebrew/bin/ (via rmarkdown)
#>  quarto   1.9.37 @ /usr/local/bin/quarto
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package     * version    date (UTC) lib source
#>  cli           3.6.6      2026-04-09 [1] CRAN (R 4.6.0)
#>  crayon        1.5.3      2024-06-20 [1] CRAN (R 4.6.0)
#>  curl          7.1.0      2026-04-22 [1] CRAN (R 4.6.0)
#>  debugme       1.2.0      2024-04-25 [1] CRAN (R 4.6.0)
#>  desc          1.4.3      2023-12-10 [1] CRAN (R 4.6.0)
#>  digest        0.6.39     2025-11-19 [1] CRAN (R 4.6.0)
#>  evaluate      1.0.5      2025-08-27 [1] CRAN (R 4.6.0)
#>  fastmap       1.2.0      2024-05-15 [1] CRAN (R 4.6.0)
#>  filelock      1.0.3      2023-12-11 [1] CRAN (R 4.6.0)
#>  fs            2.1.0      2026-04-18 [1] CRAN (R 4.6.0)
#>  glue          1.8.1      2026-04-17 [1] CRAN (R 4.6.0)
#>  htmltools     0.5.9      2025-12-04 [1] CRAN (R 4.6.0)
#>  jsonlite      2.0.0      2025-03-27 [1] CRAN (R 4.6.0)
#>  knitr         1.51       2025-12-20 [1] CRAN (R 4.6.0)
#>  lifecycle     1.0.5      2026-01-08 [1] CRAN (R 4.6.0)
#>  lpSolve       5.6.23     2024-12-14 [1] CRAN (R 4.6.0)
#>  otel          0.2.0      2025-08-29 [1] CRAN (R 4.6.0)
#>  pillar        1.11.1     2025-09-17 [1] CRAN (R 4.6.0)
#>  pkgcache      2.2.5      2026-04-09 [1] CRAN (R 4.6.0)
#>  pkgdepends  * 0.9.1.9000 2026-05-19 [1] local
#>  processx      3.9.0      2026-04-22 [1] CRAN (R 4.6.0)
#>  R6            2.6.1      2025-02-15 [1] CRAN (R 4.6.0)
#>  reprex        2.1.1      2024-07-06 [1] CRAN (R 4.6.0)
#>  rlang         1.2.0      2026-04-06 [1] CRAN (R 4.6.0)
#>  rmarkdown     2.31       2026-03-26 [1] CRAN (R 4.6.0)
#>  rstudioapi    0.18.0     2026-01-16 [1] CRAN (R 4.6.0)
#>  sessioninfo   1.2.3      2025-02-05 [1] CRAN (R 4.6.0)
#>  vctrs         0.7.3      2026-04-11 [1] CRAN (R 4.6.0)
#>  withr         3.0.2      2024-10-28 [1] CRAN (R 4.6.0)
#>  xfun          0.57       2026-03-20 [1] CRAN (R 4.6.0)
#>  yaml          2.3.12     2025-12-10 [1] CRAN (R 4.6.0)
#> 
#>  [1] /Library/Frameworks/R.framework/Versions/4.6/Resources/library
#>  * ── Packages attached to the search path.
#> 
#> ──────────────────────────────────────────────────────────────────────────────
```

</details>
