### PR TITLE
test: use a deterministic token for fake GitHub app tests

### DIFF
--- a/tests/testthat/helper-apps.R
+++ b/tests/testthat/helper-apps.R
@@ -334,10 +334,22 @@ fake_gh <- webfakes::local_app_process(
   opts = webfakes::server_opts(num_threads = 3)
 )
 
+# A deterministic, well-formed GitHub token for the fake GitHub app. It is not
+# a real credential, but it matches `re_gh_auth()` so the fake app accepts it.
+fake_gh_token <- "0123456789abcdef0123456789abcdef01234567"
+
 setup_fake_gh_app <- function(.local_envir = parent.frame()) {
   withr::local_envvar(
     .local_envir = .local_envir,
-    R_PKG_GITHUB_API_URL = fake_gh$url()
+    R_PKG_GITHUB_API_URL = fake_gh$url(),
+    # Point all token sources at a known-good fake token, so requests to the
+    # fake GitHub app never depend on ambient credentials. Otherwise a real
+    # token from the environment (e.g. `GITHUB_PAT` set to `secrets.GITHUB_TOKEN`
+    # on CI) leaks in and is rejected by the fake app as invalid.
+    CI_GITHUB_TOKEN = fake_gh_token,
+    GITHUB_PAT_GITHUB_COM = fake_gh_token,
+    GITHUB_PAT = fake_gh_token,
+    GITHUB_TOKEN = fake_gh_token
   )
 }
 

--- a/tests/testthat/helper-apps.R
+++ b/tests/testthat/helper-apps.R
@@ -334,31 +334,21 @@ fake_gh <- webfakes::local_app_process(
   opts = webfakes::server_opts(num_threads = 3)
 )
 
-# A deterministic, well-formed GitHub token for the fake GitHub app. It is not
-# a real credential, but it matches `re_gh_auth()` so the fake app accepts it.
-fake_gh_token <- "0123456789abcdef0123456789abcdef01234567"
-
-# Point all token sources at a known-good fake token, so requests to a fake
-# GitHub app never depend on ambient credentials. Otherwise a real token from
-# the environment (e.g. `GITHUB_PAT` set to `secrets.GITHUB_TOKEN` on CI) leaks
-# in and is rejected by the fake app as invalid. Use this alongside a manually
-# configured `R_PKG_GITHUB_API_URL`; `setup_fake_gh_app()` calls it for you.
-local_fake_gh_token <- function(.local_envir = parent.frame()) {
+local_fake_gh_token <- function(app = fake_gh, .local_envir = parent.frame()) {
+  app_url <- app$url()
+  ev <- gitcreds_cache_envvar(app_url)
   withr::local_envvar(
-    .local_envir = .local_envir,
-    CI_GITHUB_TOKEN = fake_gh_token,
-    GITHUB_PAT_GITHUB_COM = fake_gh_token,
-    GITHUB_PAT = fake_gh_token,
-    GITHUB_TOKEN = fake_gh_token
+    structure(strrep("0", 40), names = ev),
+    .local_envir = .local_envir
   )
 }
 
-setup_fake_gh_app <- function(.local_envir = parent.frame()) {
+setup_fake_gh_app <- function(app = fake_gh, .local_envir = parent.frame()) {
   withr::local_envvar(
     .local_envir = .local_envir,
-    R_PKG_GITHUB_API_URL = fake_gh$url()
+    R_PKG_GITHUB_API_URL = app$url()
   )
-  local_fake_gh_token(.local_envir = .local_envir)
+  local_fake_gh_token(app, .local_envir = .local_envir)
 }
 
 

--- a/tests/testthat/helper-apps.R
+++ b/tests/testthat/helper-apps.R
@@ -338,19 +338,27 @@ fake_gh <- webfakes::local_app_process(
 # a real credential, but it matches `re_gh_auth()` so the fake app accepts it.
 fake_gh_token <- "0123456789abcdef0123456789abcdef01234567"
 
-setup_fake_gh_app <- function(.local_envir = parent.frame()) {
+# Point all token sources at a known-good fake token, so requests to a fake
+# GitHub app never depend on ambient credentials. Otherwise a real token from
+# the environment (e.g. `GITHUB_PAT` set to `secrets.GITHUB_TOKEN` on CI) leaks
+# in and is rejected by the fake app as invalid. Use this alongside a manually
+# configured `R_PKG_GITHUB_API_URL`; `setup_fake_gh_app()` calls it for you.
+local_fake_gh_token <- function(.local_envir = parent.frame()) {
   withr::local_envvar(
     .local_envir = .local_envir,
-    R_PKG_GITHUB_API_URL = fake_gh$url(),
-    # Point all token sources at a known-good fake token, so requests to the
-    # fake GitHub app never depend on ambient credentials. Otherwise a real
-    # token from the environment (e.g. `GITHUB_PAT` set to `secrets.GITHUB_TOKEN`
-    # on CI) leaks in and is rejected by the fake app as invalid.
     CI_GITHUB_TOKEN = fake_gh_token,
     GITHUB_PAT_GITHUB_COM = fake_gh_token,
     GITHUB_PAT = fake_gh_token,
     GITHUB_TOKEN = fake_gh_token
   )
+}
+
+setup_fake_gh_app <- function(.local_envir = parent.frame()) {
+  withr::local_envvar(
+    .local_envir = .local_envir,
+    R_PKG_GITHUB_API_URL = fake_gh$url()
+  )
+  local_fake_gh_token(.local_envir = .local_envir)
 }
 
 

--- a/tests/testthat/helper-apps.R
+++ b/tests/testthat/helper-apps.R
@@ -334,21 +334,31 @@ fake_gh <- webfakes::local_app_process(
   opts = webfakes::server_opts(num_threads = 3)
 )
 
-local_fake_gh_token <- function(app = fake_gh, .local_envir = parent.frame()) {
-  app_url <- app$url()
-  ev <- gitcreds_cache_envvar(app_url)
+# A deterministic, well-formed GitHub token for the fake GitHub app. It is not
+# a real credential, but it matches `re_gh_auth()` so the fake app accepts it.
+fake_gh_token <- "0123456789abcdef0123456789abcdef01234567"
+
+# Point all token sources at a known-good fake token, so requests to a fake
+# GitHub app never depend on ambient credentials. Otherwise a real token from
+# the environment (e.g. `GITHUB_PAT` set to `secrets.GITHUB_TOKEN` on CI) leaks
+# in and is rejected by the fake app as invalid. Use this alongside a manually
+# configured `R_PKG_GITHUB_API_URL`; `setup_fake_gh_app()` calls it for you.
+local_fake_gh_token <- function(.local_envir = parent.frame()) {
   withr::local_envvar(
-    structure(strrep("0", 40), names = ev),
-    .local_envir = .local_envir
+    .local_envir = .local_envir,
+    CI_GITHUB_TOKEN = fake_gh_token,
+    GITHUB_PAT_GITHUB_COM = fake_gh_token,
+    GITHUB_PAT = fake_gh_token,
+    GITHUB_TOKEN = fake_gh_token
   )
 }
 
-setup_fake_gh_app <- function(app = fake_gh, .local_envir = parent.frame()) {
+setup_fake_gh_app <- function(.local_envir = parent.frame()) {
   withr::local_envvar(
     .local_envir = .local_envir,
-    R_PKG_GITHUB_API_URL = app$url()
+    R_PKG_GITHUB_API_URL = fake_gh$url()
   )
-  local_fake_gh_token(app, .local_envir = .local_envir)
+  local_fake_gh_token(.local_envir = .local_envir)
 }
 
 

--- a/tests/testthat/test-github-tools.R
+++ b/tests/testthat/test-github-tools.R
@@ -158,6 +158,7 @@ test_that("cannot parse DESCRIPTION on GH", {
 })
 
 test_that("http error", {
+  setup_fake_gh_app()
   withr::local_envvar(
     R_PKG_GITHUB_API_URL = paste0(fake_gh$url(), "/404")
   )

--- a/tests/testthat/test-solve-conflicts.R
+++ b/tests/testthat/test-solve-conflicts.R
@@ -60,7 +60,7 @@ test_that("direct CRAN conflicts with downstream GH dep", {
     gh_app(gh)
   )
   withr::local_envvar(R_PKG_GITHUB_API_URL = fake_gh$url())
-  local_fake_gh_token()
+  local_fake_gh_token(app = fake_gh)
   setup_fake_apps()
 
   lib <- withr::local_tempdir()

--- a/tests/testthat/test-solve-conflicts.R
+++ b/tests/testthat/test-solve-conflicts.R
@@ -60,6 +60,7 @@ test_that("direct CRAN conflicts with downstream GH dep", {
     gh_app(gh)
   )
   withr::local_envvar(R_PKG_GITHUB_API_URL = fake_gh$url())
+  local_fake_gh_token()
   setup_fake_apps()
 
   lib <- withr::local_tempdir()

--- a/tests/testthat/test-solve-conflicts.R
+++ b/tests/testthat/test-solve-conflicts.R
@@ -60,7 +60,7 @@ test_that("direct CRAN conflicts with downstream GH dep", {
     gh_app(gh)
   )
   withr::local_envvar(R_PKG_GITHUB_API_URL = fake_gh$url())
-  local_fake_gh_token(app = fake_gh)
+  local_fake_gh_token()
   setup_fake_apps()
 
   lib <- withr::local_tempdir()

--- a/tests/testthat/test-solve-describe.R
+++ b/tests/testthat/test-solve-describe.R
@@ -98,7 +98,7 @@ test_that("conflicting dependencies and installed packages", {
 
   fake_gh <- webfakes::local_app_process(gh_app(gh))
   withr::local_envvar(R_PKG_GITHUB_API_URL = fake_gh$url())
-  local_fake_gh_token(fake_gh)
+  local_fake_gh_token()
   setup_fake_apps(cran_repo = cran)
 
   # -----------------------------------------------------------------------

--- a/tests/testthat/test-solve-describe.R
+++ b/tests/testthat/test-solve-describe.R
@@ -98,7 +98,7 @@ test_that("conflicting dependencies and installed packages", {
 
   fake_gh <- webfakes::local_app_process(gh_app(gh))
   withr::local_envvar(R_PKG_GITHUB_API_URL = fake_gh$url())
-  local_fake_gh_token()
+  local_fake_gh_token(fake_gh)
   setup_fake_apps(cran_repo = cran)
 
   # -----------------------------------------------------------------------

--- a/tests/testthat/test-solve-describe.R
+++ b/tests/testthat/test-solve-describe.R
@@ -98,6 +98,7 @@ test_that("conflicting dependencies and installed packages", {
 
   fake_gh <- webfakes::local_app_process(gh_app(gh))
   withr::local_envvar(R_PKG_GITHUB_API_URL = fake_gh$url())
+  local_fake_gh_token()
   setup_fake_apps(cran_repo = cran)
 
   # -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The new `test-coverage` workflow (`uncovr::test()`) runs the full testthat suite, unlike `R CMD check`, which only runs the `scan-deps` tests (`tests/testthat.R` filters to them). This surfaced 15 failures in `test-github-tools.R`: the fake GitHub app validates the `Authorization` header format via `re_gh_auth()`, but the tests relied on whatever ambient credential `type_github_get_headers()` found. On CI, `GITHUB_PAT` is set to `secrets.GITHUB_TOKEN`; with no git credential helper present, `gitcreds_get()` returns it, the fake app rejects it as malformed, and every snapshot fails with HTTP 401.

This makes the fake-app tests hermetic: `setup_fake_gh_app()` now pins all token sources (`CI_GITHUB_TOKEN`, `GITHUB_PAT_GITHUB_COM`, `GITHUB_PAT`, `GITHUB_TOKEN`) to a deterministic, well-formed fake token, so requests never depend on ambient credentials. The `http error` test now calls `setup_fake_gh_app()` too (it set the API URL manually and missed the token vars). Tests that exercise bad-credential paths still set their own token values after `setup_fake_gh_app()`, so they are unaffected.

## Verification

Under a simulated CI runner (`CI=true`, no credential helper, a malformed ambient `GITHUB_PAT`): `test-github-tools.R` 31 passed (was 15 failing), `test-type-github.R` 177 passed, `test-type-url.R` 21 passed. All also pass in the normal local environment.