### PR TITLE
Do not install sysreqs for manylinux binaries

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # pkgdepends (development version)
 
+* pkgdepends now skips the system requirements of binary packages that come
+  from a Posit Package Manager `manylinux` repository
+  (https://github.com/r-lib/pak/issues/815).
+
 * Blank lines in `.Rbuildignore` no longer cause all git submodules of a
   package to be skipped, empty lines are now dropped (#480).
 

--- a/R/install-plan.R
+++ b/R/install-plan.R
@@ -1003,6 +1003,19 @@ handle_install_needs_build <- function(state, worker) {
      will build it from source"
   )
 
+  if (plan_sysreqs_suppressed(state$plan, pkgidx)) {
+    alert(
+      "warning",
+      paste0(
+        "Did not install the system requirements of {.pkg {pkg}}, because it ",
+        "was supposed to be a self-contained binary package. If the build ",
+        "fails, you might need to install them manually: ",
+        "{.val {state$plan$sysreqs[[pkgidx]]}}."
+      ),
+      wrap = TRUE
+    )
+  }
+
   state$plan$binary[[pkgidx]] <- FALSE
   state$plan$build_done[[pkgidx]] <- FALSE
   state$plan$worker_id[[pkgidx]] <- NA_character_
@@ -1052,6 +1065,14 @@ check_source_fallback_linkingto <- function(plan, pkgidx) {
       and try again, to always include {.code LinkingTo} dependencies in the
       installation plan."
   ))
+}
+
+plan_sysreqs_suppressed <- function(plan, pkgidx) {
+  if (!all(c("mirror", "sysreqs") %in% names(plan))) {
+    return(FALSE)
+  }
+  sq <- plan$sysreqs[[pkgidx]]
+  !is.na(sq) && nzchar(sq) && is_ppm_manylinux_repo(plan$mirror[[pkgidx]])
 }
 
 source_deps <- function(plan, pkgidx) {

--- a/R/resolution.R
+++ b/R/resolution.R
@@ -248,7 +248,9 @@ res_init <- function(self, private, config, cache, library, remote_types) {
       fail_val <- data_frame(
         ref = rec$ref,
         type = vcapply(rec$remote, "[[", "type"),
-        package = vcapply(rec$remote, function(r) r$package %|z|% NA_character_),
+        package = vcapply(rec$remote, function(r) {
+          r$package %|z|% NA_character_
+        }),
         version = NA_character_,
         sources = replicate(nrow(rec), NA_character_, simplify = FALSE),
         direct = rec$direct,
@@ -445,7 +447,13 @@ res__set_result_list <- function(self, private, row_idx, value) {
 
 res__sysreqs_match <- function(self, private) {
   if ("sysreqs" %in% names(self$result)) {
-    sys <- sysreqs2_match(self$result$sysreqs, config = private$config)
+    # Manylinux binaries don't need system packages.
+    sysreqs <- self$result$sysreqs
+    sysreqs[binary_needs_no_sysreqs(
+      self$result$platform,
+      self$result$mirror
+    )] <- NA_character_
+    sys <- sysreqs2_match(sysreqs, config = private$config)
     if (!is.null(spkgs <- private$system_packages)) {
       spkgs <- spkgs[grepl("^.i$", spkgs$status), ] # nocovif !is_linux()
       allspkgs <- unique(unlist(c(spkgs$package, spkgs$provides))) # nocovif !is_linux()

--- a/R/sysreqs2.R
+++ b/R/sysreqs2.R
@@ -334,6 +334,29 @@ sysreqs2_match <- function(
   result
 }
 
+# Same as pkgcache. E.g. https://p3m.dev/cran/__linux__/manylinux_2_28/latest
+
+re_ppm_linux_repo <- function() {
+  paste0(
+    "^",
+    "(?<base>.*/)",
+    "(?<repo>[^/]+)/",
+    "__linux__/",
+    "(?<distro>[a-zA-Z0-9_]+)/",
+    "(?<version>latest|[-0-9]+)",
+    "$"
+  )
+}
+
+is_ppm_manylinux_repo <- function(urls) {
+  mch <- re_match(sub("/+$", "", as.character(urls)), re_ppm_linux_repo())
+  !is.na(mch$.match) & grepl("^manylinux", mch$distro)
+}
+
+binary_needs_no_sysreqs <- function(platform, mirror) {
+  !is.na(platform) & platform != "source" & is_ppm_manylinux_repo(mirror)
+}
+
 sysreqs_update_state <- function(sys, spkgs = NULL) {
   spkgs <- spkgs %||% sysreqs_list_system_packages()
   spkgs <- spkgs[grepl("^.i$", spkgs$status), ]

--- a/tests/testthat/_snaps/install-plan.md
+++ b/tests/testthat/_snaps/install-plan.md
@@ -101,3 +101,14 @@
       ! Failed to build goodbuild 1.0.0
       v Summary:   2 new
 
+# handle_install_needs_build warns about skipped sysreqs
+
+    Code
+      state <- handle_install_needs_build(state, worker)
+    Message
+      i A 1.0.0 was served as a source package,
+      will build it from source
+      ! Did not install the system requirements of A, because it was supposed to be a
+      self-contained binary package. If the build fails, you might need to install
+      them manually: "libcurl".
+

--- a/tests/testthat/test-install-plan.R
+++ b/tests/testthat/test-install-plan.R
@@ -422,3 +422,54 @@ test_that("install package from GH, in subdir", {
   # cache is updated with the source and binary
   check_cache()
 })
+
+test_that("plan_sysreqs_suppressed", {
+  ppm <- "https://p3m.dev/cran/__linux__/manylinux_2_28/latest"
+  plan <- data_frame(
+    package = c("A", "B", "C", "D"),
+    mirror = c(ppm, "https://p3m.dev/cran/__linux__/noble/latest", ppm, ppm),
+    sysreqs = c("libcurl", "libcurl", NA_character_, "")
+  )
+  expect_true(plan_sysreqs_suppressed(plan, 1L))
+  # not a manylinux repo
+  expect_false(plan_sysreqs_suppressed(plan, 2L))
+  # nothing was declared, so nothing was suppressed
+  expect_false(plan_sysreqs_suppressed(plan, 3L))
+  expect_false(plan_sysreqs_suppressed(plan, 4L))
+
+  # a plan created from a lock file has no `mirror` column
+  plan$mirror <- NULL
+  expect_false(plan_sysreqs_suppressed(plan, 1L))
+})
+
+test_that("handle_install_needs_build warns about skipped sysreqs", {
+  local_cli_config()
+  # A was supposed to be a self-contained manylinux binary, so we did not
+  # install its system requirements, but now we have to build it.
+  plan <- data_frame(
+    package = "A",
+    version = "1.0.0",
+    binary = TRUE,
+    needscompilation = "no",
+    mirror = "https://p3m.dev/cran/__linux__/manylinux_2_28/latest",
+    sysreqs = "libcurl",
+    dependencies = list(character()),
+    deps = list(data_frame(package = character(), type = character())),
+    dep_types = list(pkg_dep_types_hard()),
+    build_done = TRUE,
+    install_done = FALSE,
+    worker_id = NA_character_,
+    deps_left = list(character())
+  )
+  state <- list(plan = plan, workers = list(), config = list())
+  worker <- list(
+    task = list(args = list(pkgidx = 1L)),
+    result = structure(
+      list(needscompilation = "yes"),
+      class = "install_needs_build"
+    )
+  )
+
+  expect_snapshot(state <- handle_install_needs_build(state, worker))
+  expect_false(state$plan$binary[[1]])
+})

--- a/tests/testthat/test-resolution.R
+++ b/tests/testthat/test-resolution.R
@@ -499,3 +499,51 @@ test_that("a failing batch resolution fails all its refs (#462)", {
   expect_match(conditionMessage(failed$error[[1]]$parent), "metadata boom")
   expect_match(conditionMessage(failed$error[[2]]$parent), "metadata boom")
 })
+
+test_that("no sysreqs for PPM manylinux binaries", {
+  # PPM's manylinux binaries are self-contained, so we must not compute
+  # (and later install) system packages for them. We do keep the declared
+  # `SystemRequirements` string.
+  ppm <- "https://p3m.dev/cran/__linux__/manylinux_2_28/latest"
+  res <- make_fake_resolution(
+    # manylinux binary: suppressed
+    "curl" = list(
+      mirror = ppm,
+      platform = "x86_64-pc-linux-gnu",
+      sysreqs = "libcurl"
+    ),
+    # source package from the same repo: not suppressed
+    "xml2" = list(mirror = ppm, platform = "source", sysreqs = "libxml2"),
+    # binary from another repo: not suppressed
+    "openssl" = list(
+      mirror = "https://p3m.dev/cran/__linux__/noble/latest",
+      platform = "x86_64-pc-linux-gnu",
+      sysreqs = "openssl"
+    )
+  )
+
+  self <- new.env(parent = emptyenv())
+  self$result <- res
+  private <- list(
+    config = current_config()$update(list(sysreqs_platform = "ubuntu-22.04")),
+    system_packages = NULL
+  )
+  res__sysreqs_match(self, private)
+
+  # the raw `SystemRequirements` string is kept for all of them
+  expect_equal(self$result$sysreqs, c("libcurl", "libxml2", "openssl"))
+
+  # but no system packages, and no commands, for the manylinux binary
+  expect_null(self$result$sysreqs_packages[[1]])
+  expect_equal(self$result$sysreqs_pre_install[[1]], "")
+  expect_equal(self$result$sysreqs_install[[1]], "")
+  expect_equal(self$result$sysreqs_post_install[[1]], "")
+
+  # the other two are matched as usual
+  expect_equal(
+    vcapply(self$result$sysreqs_packages[[2]], "[[", "sysreq"),
+    "libxml2"
+  )
+  expect_match(self$result$sysreqs_install[[2]], "libxml2-dev")
+  expect_match(self$result$sysreqs_install[[3]], "libssl-dev")
+})

--- a/tests/testthat/test-sysreqs2.R
+++ b/tests/testthat/test-sysreqs2.R
@@ -241,3 +241,56 @@ test_that("sysreqs2_scripts deduplicates repeated pre/post_install commands", {
   expect_equal(scripts$post_install, post)
   expect_true(rust %in% scripts$pre_install)
 })
+
+test_that("is_ppm_manylinux_repo", {
+  expect_true(is_ppm_manylinux_repo(
+    "https://p3m.dev/cran/__linux__/manylinux_2_28/latest"
+  ))
+  # trailing slash, dated snapshot, other PPM host, future manylinux version
+  expect_true(is_ppm_manylinux_repo(
+    "https://p3m.dev/cran/__linux__/manylinux_2_28/latest/"
+  ))
+  expect_true(is_ppm_manylinux_repo(
+    "https://packagemanager.posit.co/cran/__linux__/manylinux_2_28/2026-01-01"
+  ))
+  expect_true(is_ppm_manylinux_repo(
+    "https://p3m.dev/cran/__linux__/manylinux_2_34/latest"
+  ))
+
+  # a regular PPM Linux repo, a plain CRAN-like repo, and no repo at all
+  expect_false(is_ppm_manylinux_repo(
+    "https://p3m.dev/cran/__linux__/noble/latest"
+  ))
+  expect_false(is_ppm_manylinux_repo("https://cran.r-project.org"))
+  expect_false(is_ppm_manylinux_repo(NA_character_))
+
+  # vectorized, including the zero length case
+  expect_equal(
+    is_ppm_manylinux_repo(c(
+      "https://p3m.dev/cran/__linux__/manylinux_2_28/latest",
+      "https://p3m.dev/cran/__linux__/jammy/latest",
+      NA_character_
+    )),
+    c(TRUE, FALSE, FALSE)
+  )
+  expect_equal(is_ppm_manylinux_repo(character()), logical())
+})
+
+test_that("binary_needs_no_sysreqs", {
+  ppm <- "https://p3m.dev/cran/__linux__/manylinux_2_28/latest"
+  expect_true(binary_needs_no_sysreqs("x86_64-pc-linux-gnu", ppm))
+  # PPM uses an empty platform string for packages that need no compilation
+  expect_true(binary_needs_no_sysreqs("", ppm))
+
+  # source packages from the same repo do need their system requirements
+  expect_false(binary_needs_no_sysreqs("source", ppm))
+  # binaries from anywhere else are unaffected
+  expect_false(binary_needs_no_sysreqs(
+    "x86_64-pc-linux-gnu",
+    "https://p3m.dev/cran/__linux__/noble/latest"
+  ))
+  expect_false(binary_needs_no_sysreqs("x86_64-pc-linux-gnu", NA_character_))
+  expect_false(binary_needs_no_sysreqs(NA_character_, ppm))
+
+  expect_equal(binary_needs_no_sysreqs(character(), character()), logical())
+})


### PR DESCRIPTION
Note that `sysreqs_check_installed()` and `sysreqs_fix_installed()` do not works correctly currently with manylinux packages.

Closes #815.